### PR TITLE
Optimize `ParquetReader`

### DIFF
--- a/src/datatrove/pipeline/readers/parquet.py
+++ b/src/datatrove/pipeline/readers/parquet.py
@@ -31,10 +31,12 @@ class ParquetReader(BaseReader):
                 li = 0
                 columns = [self.content_key, self.id_key] if not self.read_metadata else None
                 for batch in pqf.iter_batches(batch_size=self.batch_size, columns=columns):
-                    with self.track_time():
+                    documents = []
+                    with self.track_time("batch"):
                         for line in batch.to_pylist():
                             document = self.get_document_from_dict(line, datafile, li)
                             if not document:
                                 continue
+                            documents.append(document)
                             li += 1
-                            yield document
+                    yield from documents


### PR DESCRIPTION
Optimize the `ParquetReader` component by reading files in chunks (of size 1000) and only decoding the `content_key` column (reads less bytes and makes the Arrow to Python conversion faster)

This Colab shows the difference in speed:
https://colab.research.google.com/drive/14c1lvasWYg0ScsIxeTZcqIUVV8ulCYUi?usp=sharing