### PR TITLE
Support Python 3.11/3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
     keywords="data machine learning processing",


### PR DESCRIPTION
Replace `cchardet` with `faust-ccardet` (not maintained) to support Python 3.11/3.12 and relax the PyArrow (14.0.1 is needed to address the https://www.cve.org/CVERecord?id=CVE-2023-47248 vulnerability), NumPy and Tokenizers (to support Python 3.12) version requirements. Also, test Python 3.11/3.12 in CI.