### PR TITLE
Use re search instead of findall

### DIFF
--- a/src/datatrove/pipeline/filters/regex_filter.py
+++ b/src/datatrove/pipeline/filters/regex_filter.py
@@ -24,4 +24,4 @@ class RegexFilter(BaseFilter):
         Returns:
             is_filter
         """
-        return not len(self.regex.findall(doc.text)) > 0
+        return not self.regex.search(doc.text)


### PR DESCRIPTION
In the regex docstring is written "filters if regex find at least one match". This means that findall is an overkill, as we are not actually interested in all occurrences. For a few datapoints this might not be noticeable and depending on the regex pattern, it will also not make a difference. But in some cases this could lead to a speed up of the pipeline, so I guess would be worth changing.