### PR TITLE
Zero Division Error Fix

### DIFF
--- a/src/datatrove/pipeline/filters/unigram_log_probs.py
+++ b/src/datatrove/pipeline/filters/unigram_log_probs.py
@@ -56,9 +56,7 @@ class UnigramLogProbFilter(BaseFilter):
         from nltk.tokenize import word_tokenize
 
         words = word_tokenize(doc.text)
-        freqs = [
-            self.unigram_frequencies.get(word.lower(), 0) for word in words
-        ]
+        freqs = [self.unigram_frequencies.get(word.lower(), 1e-9) for word in words]
 
         if len(freqs) == 0:
             return 0

--- a/src/datatrove/pipeline/filters/unigram_log_probs.py
+++ b/src/datatrove/pipeline/filters/unigram_log_probs.py
@@ -57,7 +57,7 @@ class UnigramLogProbFilter(BaseFilter):
 
         words = word_tokenize(doc.text)
         freqs = [
-            self.unigram_frequencies.get(word.lower()) for word in words if self.unigram_frequencies.get(word.lower())
+            self.unigram_frequencies.get(word.lower(), 0) for word in words
         ]
 
         if len(freqs) == 0:

--- a/src/datatrove/pipeline/filters/unigram_log_probs.py
+++ b/src/datatrove/pipeline/filters/unigram_log_probs.py
@@ -59,6 +59,9 @@ class UnigramLogProbFilter(BaseFilter):
         freqs = [
             self.unigram_frequencies.get(word.lower()) for word in words if self.unigram_frequencies.get(word.lower())
         ]
+
+        if len(freqs) == 0:
+            return 0
         return sum([np.log(f) for f in freqs]) / len(freqs)
 
     def filter(self, doc: Document) -> bool:


### PR DESCRIPTION
Add an if statement to check if len(freq) is 0. If it is, 0 is returned. This prevents zero division error.