### PR TITLE
Added upload_block_size parameter

### DIFF
--- a/src/datatrove/pipeline/tokens/merger.py
+++ b/src/datatrove/pipeline/tokens/merger.py
@@ -22,6 +22,9 @@ class DocumentTokenizerMerger(PipelineStep):
         max_tokens_per_file: int = 100e9,  # max number of tokens per file. default: 100GT
         max_tokens: int = -1,  # max number of tokens to process
         shuffle: bool = True,  # whether to shuffle documents in the dataset
+        upload_block_size: int = 20 * 2**20,  # 20MB
+        # upload_block_size * 10000 must be bigger than 2*max_tokens_per_file,
+        # or s3 uploads will fail
         seed: int = None,
         save_loss_metadata: bool = False,
         save_final_metadata: bool = True,
@@ -36,6 +39,7 @@ class DocumentTokenizerMerger(PipelineStep):
         self.save_loss_metadata = save_loss_metadata
         self.rand = default_rng(seed)
         self.save_final_metadata = save_final_metadata
+        self.upload_block_size = upload_block_size
 
     def get_ordering(self, all_doc_ends):
         doc_ids = np.concatenate([np.ones(len(doc_ends), dtype=int) * i for i, doc_ends in enumerate(all_doc_ends)])
@@ -79,6 +83,7 @@ class DocumentTokenizerMerger(PipelineStep):
             output_folder=self.output_folder,
             filename=f"{file_ct:03d}_{self.save_filename}.ds",
             save_loss_metadata=self.save_loss_metadata,
+            upload_block_size=self.upload_block_size,
         )
         for input_file_id in ordering:
             if 0 < self.max_tokens <= self.stats["tokens"].total:


### PR DESCRIPTION
S3 streaming uploads seem to default to a chunk size of `5MB` (`5 * 2**20`). As s3 has a limit of 10000 parts, this limit is not enough for a file with 100GTokens (`100e9` tokens, at `2` bytes per token is `200e9` bytes which is bigger than `10000 * 5 * 2**20`).
This PR makes it possible to set the `block_size` and uses `20MB` as a default.