### PR TITLE
Add prefix to slurm logs

### DIFF
--- a/src/datatrove/executor/slurm.py
+++ b/src/datatrove/executor/slurm.py
@@ -45,7 +45,7 @@ class SlurmPipelineExecutor(PipelineExecutor):
         mem_per_cpu_gb: int = 2,
         workers: int = -1,
         job_name: str = "data_processing",
-        logs_prefix : str = "",
+        logs_prefix: str = "",
         qos: str = "normal",
         env_command: str = None,
         condaenv: str = None,


### PR DESCRIPTION
option to add a prefix to slurm logs (could be useful when tokenizing multiple sources in the same `logging_dir`)