### PR TITLE
Efficiency: np.fromiter instead of np.array

### DIFF
--- a/src/datatrove/pipeline/dedup/bloom_filter.py
+++ b/src/datatrove/pipeline/dedup/bloom_filter.py
@@ -100,13 +100,13 @@ class SingleBloomFilter(PipelineStep):
     def get_shingles(self, text: str) -> np.ndarray:
         from nltk import ngrams, word_tokenize
 
-        return np.array(
+        return np.fromiter(
             [
-                [sha1_hash32(" ".join(x).encode("utf-8"))]
+                sha1_hash32(" ".join(x).encode("utf-8"))
                 for x in ngrams(word_tokenize(simplify_text(text)), self.n_grams)
             ],
             dtype=np.uint64,
-        )
+        ).reshape((-1, 1))
 
     def get_indexes(self, shingles: np.ndarray) -> list[list[int]]:
         a, b = self.parameters

--- a/src/datatrove/pipeline/dedup/exact_substrings.py
+++ b/src/datatrove/pipeline/dedup/exact_substrings.py
@@ -32,7 +32,7 @@ SEPARATOR_BYTES = 12
 
 def prepare_doc(tokenizer, doc: str, rank: int, doc_id: int):
     tokens = tokenizer.encode(doc).ids
-    tokens = np.array(tokens, dtype=np.uint16)
+    tokens = np.fromiter(tokens, dtype=np.uint16, count=len(tokens))
     b_doc = b"\xff\xff" + struct.pack("<I", doc_id) + b"\xff\xff" + struct.pack("<I", rank) + tokens.tobytes()
     return b_doc
 

--- a/src/datatrove/pipeline/dedup/minhash.py
+++ b/src/datatrove/pipeline/dedup/minhash.py
@@ -186,13 +186,13 @@ class MinhashDedupSignature(PipelineStep):
     def get_shingles(self, text):
         from nltk import ngrams, word_tokenize
 
-        return np.array(
+        return np.fromiter(
             [
-                [self._hash_func(" ".join(x).encode("utf-8"))]
+                self._hash_func(" ".join(x).encode("utf-8"))
                 for x in ngrams(word_tokenize(simplify_text(text)), self.config.n_grams)
             ],
             dtype=np.uint64,
-        )
+        ).reshape((-1, 1))
 
     def run(self, data: DocumentsPipeline, rank: int = 0, world_size: int = 1):
         buckets = [


### PR DESCRIPTION
Hello Guilherme!!! Very nice repo! I am trying to use it for a little project of mine! ❤️‍🔥 

Replacing `np.array` with `np.fromiter` makes us spare up to ~20% time in the array creation.
It's little, but the function `prepare_doc` gets spammed... 🤗 
A famous man once said: _"a single spark can start a prairie fire"_🛠️ 

I guess that when the input is a list of numbers, this approach eats some overhead, because `np.array` is supposed to work with any kind of object while `np.fromiter` is more specific of iterables, such as lists.

It's kind of black magic, I found it out while trying to speedup a pipeline not so long ago!

Look:
```python
import numpy as np
import time
from scipy.stats import wilcoxon

for n in [10**x for x in range(1, 5)]:
    method_array = []
    method_fromiter = []
    for k in range(100000):
        token_list = np.random.randint(0, 65535, size=n, dtype=np.uint16).tolist()
        start_time = time.time()
        np.array(token_list, dtype=np.uint16)
        method_array.append(time.time() - start_time)
        start_time = time.time()
        np.fromiter(token_list, dtype=np.uint16, count=len(token_list))
        method_fromiter.append(time.time() - start_time)
    _, p = wilcoxon(method_array, y=method_fromiter, zero_method='zsplit', alternative='greater') # alternative hypothesis: time of method_array >= time of method_fromiter
    print(n, p)
```
Output:
```markdown
10 0.4773584925300637
100 0.4176699785461047
1000 0.00010255560716102062
10000 2.0292562600434947e-305
```

The times are ~ identical for lists of hundreds of tokens but `np.array` gets slower for lists > 1000 tokens and this result is statistically significant (low p-value) 😮 

Launch your test suit before merging because I can not run it on windows and conda, even before the changes 😭 