### PR TITLE
Decoupled reading logic from DedupReader

### DIFF
--- a/src/datatrove/pipeline/dedup/__init__.py
+++ b/src/datatrove/pipeline/dedup/__init__.py
@@ -1,5 +1,5 @@
 from .bloom_filter import SingleBloomFilter
-from .exact_substrings import DatasetToSequence, DedupReader, MergeSequences
+from .exact_substrings import ESDatasetToSequence, ESMergeSequences, ESRangeRemover
 from .minhash import (
     MinhashBuildIndex,
     MinhashDedupBuckets,

--- a/src/datatrove/pipeline/dedup/exact_substrings.py
+++ b/src/datatrove/pipeline/dedup/exact_substrings.py
@@ -14,7 +14,7 @@ TLDR
 
 """
 import struct
-from typing import BinaryIO, Generator, Literal
+from typing import BinaryIO, Generator
 
 import numpy as np
 import tokenizers
@@ -22,7 +22,6 @@ from loguru import logger
 
 from datatrove.io import DataFolderLike, get_datafolder
 from datatrove.pipeline.base import DocumentsPipeline, PipelineStep
-from datatrove.pipeline.readers import JsonlReader
 
 from .utils import ExtensionHelperES as EH
 
@@ -37,7 +36,7 @@ def prepare_doc(tokenizer, doc: str, rank: int, doc_id: int):
     return b_doc
 
 
-class DatasetToSequence(PipelineStep):
+class ESDatasetToSequence(PipelineStep):
     """STAGE 1
     Creates a sequence of all docs pre-prepended by a unique separator. It also saves a second file with the
     bytes offset of where each individual doc begins.
@@ -76,7 +75,7 @@ class DatasetToSequence(PipelineStep):
         self.save_sizes(doc_lens, rank)
 
 
-class MergeSequences(PipelineStep):
+class ESMergeSequences(PipelineStep):
     """STAGE 2
     It merges all the sequences from stage 1 into a big sequence. It saves a file with the cumulative bytes offset
     of every single sequence.
@@ -140,21 +139,19 @@ def sequence_reader(file: BinaryIO, size_file: BinaryIO) -> Generator[list, None
                 yield f.read(n_bytes)
 
 
-class DedupReader(JsonlReader):
+class ESRangeRemover(PipelineStep):
     type = "🫂 - DEDUP"
     name = "🪞 - exact-substrings stage 3"
     _requires_dependencies = ["nltk", "tokenizers"]
 
     def __init__(
         self,
-        data_folder: DataFolderLike,
         sequence_folder: DataFolderLike,
-        compression: Literal["guess", "gzip", "zst"] | None = "guess",
         tokenizer_name: str = "gpt2",
         min_doc_words: int = 50,
         language: str = "english",
     ):
-        super().__init__(data_folder=data_folder, compression=compression)
+        super().__init__()
         self.sequence_folder = get_datafolder(sequence_folder)
         self.tokenizer = tokenizers.Tokenizer.from_pretrained(tokenizer_name)
         self.min_doc_words = min_doc_words
@@ -318,9 +315,6 @@ class DedupReader(JsonlReader):
         sequence_file, size_file = self.get_all_files(rank=self.rank, world_size=world_size)
         if not self.dup_ranges:
             return
-        # data is given only during tests.
-        if not data:
-            data = self.read_files_shard(self.data_folder.get_shard(self.rank, world_size))
         # data is still useful for the metadata lost in the sequence format.
         for doc, doc_content in zip(
             data,

--- a/tests/pipeline/test_exact_substrings.py
+++ b/tests/pipeline/test_exact_substrings.py
@@ -5,9 +5,9 @@ import unittest
 
 from datatrove.data import Document
 from datatrove.pipeline.dedup.exact_substrings import (
-    DatasetToSequence,
-    DedupReader,
-    MergeSequences,
+    ESDatasetToSequence,
+    ESMergeSequences,
+    ESRangeRemover,
     read_bytes,
     sequence_reader,
 )
@@ -184,14 +184,13 @@ class TestExactSubstr(unittest.TestCase):
     def test_signature_1_worker(self):
         data = copy.deepcopy(DATA)
 
-        dataset_to_sequence = DatasetToSequence(output_folder=self.tmp_dir)
-        merge_sequence = MergeSequences(
+        dataset_to_sequence = ESDatasetToSequence(output_folder=self.tmp_dir)
+        merge_sequence = ESMergeSequences(
             data_folder=self.tmp_dir,
             tasks_stage_1=1,
         )
 
-        dedup_reader = DedupReader(
-            data_folder=self.tmp_dir,
+        dedup_reader = ESRangeRemover(
             sequence_folder=self.tmp_dir,
             min_doc_words=0,
         )
@@ -237,14 +236,13 @@ class TestExactSubstr(unittest.TestCase):
     def test_signature_2_worker(self):
         data = copy.deepcopy(DATA)
 
-        dataset_to_sequence = DatasetToSequence(output_folder=self.tmp_dir)
-        merge_sequence = MergeSequences(
+        dataset_to_sequence = ESDatasetToSequence(output_folder=self.tmp_dir)
+        merge_sequence = ESMergeSequences(
             data_folder=self.tmp_dir,
             tasks_stage_1=2,
         )
 
-        dedup_reader = DedupReader(
-            data_folder=self.tmp_dir,
+        dedup_reader = ESRangeRemover(
             sequence_folder=self.tmp_dir,
             min_doc_words=0,
         )


### PR DESCRIPTION
- decouples document reading logic from the stage 3 exactsubstring block
- renamed blocks to include ES prefix
- renamed `DedupReader` to `ESRangeRemover`
- updated tests
- updated example