### PR TITLE
Support for arbitrary fasttext models

### DIFF
--- a/src/datatrove/pipeline/filters/__init__.py
+++ b/src/datatrove/pipeline/filters/__init__.py
@@ -1,4 +1,5 @@
 from .c4_quality_filter import C4ParagraphFilter, C4QualityFilter
+from .fasttext_filter import FastTextClassifierFilter
 from .gopher_quality_filter import GopherQualityFilter
 from .gopher_repetition_filter import GopherRepetitionFilter
 from .lambda_filter import LambdaFilter

--- a/src/datatrove/pipeline/filters/fasttext_filter.py
+++ b/src/datatrove/pipeline/filters/fasttext_filter.py
@@ -1,0 +1,62 @@
+import os
+
+from fsspec.core import strip_protocol
+from huggingface_hub import cached_assets_path
+from loguru import logger
+
+from datatrove.data import Document
+from datatrove.io import download_file
+from datatrove.pipeline.filters.base_filter import BaseFilter
+from datatrove.pipeline.writers.disk_base import DiskWriter
+
+
+class FastTextFilter(BaseFilter):
+    name = "🤖 fastText"
+    _requires_dependencies = [("fasttext", "fasttext-wheel")]
+
+    def __init__(
+        self,
+        model_url: str,
+        exclusion_writer: DiskWriter = None,
+    ):
+        """
+        filters if the predicted language is not among given language or if the language score is below language
+        language_threshold
+
+        Args:
+            model_url: url to download the model
+            exclusion_writer:
+        """
+        super().__init__(exclusion_writer)
+        self.model_url = model_url
+        self._model = None
+
+    @property
+    def model(self):
+        if not self._model:
+            from fasttext.FastText import _FastText
+
+            download_dir = cached_assets_path(library_name="datatrove", namespace="filters", subfolder="fasttext")
+
+            model_file = os.path.join(download_dir, strip_protocol(self.model_url).replace("/", "_"))
+            if not os.path.isfile(model_file):
+                logger.info(f'⬇️ Downloading fast-text model from "{self.model_url}"...')
+                download_file(self.model_url, model_file)
+                logger.info(f'⬇️ Downloaded fast-text model to "{model_file}".')
+            self._model = _FastText(model_file)
+        return self._model
+
+    def filter(self, doc: Document) -> bool:
+        """Args:
+            doc: document
+
+        Returns:
+            is_filter
+        """
+        return True
+        # language, score = self.model.predict(doc.text.replace("\n", ""))
+        # # language label is given in the form __label__<language_id>
+        # language = language[0].split("__")[2]
+        # doc.metadata["language"] = language
+        # doc.metadata["language_score"] = score[0]
+        # return score > self.language_threshold and language in self.languages

--- a/src/datatrove/pipeline/filters/fasttext_filter.py
+++ b/src/datatrove/pipeline/filters/fasttext_filter.py
@@ -28,6 +28,8 @@ class FastTextClassifierFilter(BaseFilter):
         Example:
             for `filter_labels=[("math", 0.9)]` will only keep samples with a score on __label__math of at least 0.9
 
+        Info to train your own classifier: https://fasttext.cc/docs/en/supervised-tutorial.html
+
         Args:
             model_url: url to download the model from
             filter_labels: tuple of (label name without "__label__", min score) (or list of such tuples)

--- a/src/datatrove/pipeline/filters/language_filter.py
+++ b/src/datatrove/pipeline/filters/language_filter.py
@@ -1,10 +1,10 @@
 import os
-import urllib.request
 
 from huggingface_hub import cached_assets_path
 from loguru import logger
 
 from datatrove.data import Document
+from datatrove.io import download_file
 from datatrove.pipeline.filters.base_filter import BaseFilter
 from datatrove.pipeline.writers.disk_base import DiskWriter
 from datatrove.utils.typeshelper import Languages
@@ -47,8 +47,9 @@ class LanguageFilter(BaseFilter):
             )
             model_file = os.path.join(download_dir, "lid.176.bin")
             if not os.path.isfile(model_file):
-                logger.info("⬇️ Downloading fast-text language identifier model ...")
-                urllib.request.urlretrieve(LANGUAGE_ID_MODEL_URL, model_file)
+                logger.info("⬇️ Downloading fast-text language identifier model...")
+                download_file(LANGUAGE_ID_MODEL_URL, model_file)
+                logger.info("⬇️ Downloaded fast-text language identifier model.")
             self._model = _FastText(model_file)
         return self._model
 

--- a/src/datatrove/tools/launch_pickled_pipeline.py
+++ b/src/datatrove/tools/launch_pickled_pipeline.py
@@ -3,7 +3,7 @@ import argparse
 import dill
 
 from datatrove.executor.base import PipelineExecutor
-from datatrove.io import get_file
+from datatrove.io import open_file
 
 
 parser = argparse.ArgumentParser("Loads a pickled pipeline executor and launches it.")
@@ -13,7 +13,7 @@ parser.add_argument("path", type=str, help="Path to the pickled file (usually a 
 
 def main():
     args = parser.parse_args()
-    with get_file(args.path, "rb") as f:
+    with open_file(args.path, "rb") as f:
         executor: PipelineExecutor = dill.load(f)
     executor.run()
 

--- a/src/datatrove/tools/merge_stats.py
+++ b/src/datatrove/tools/merge_stats.py
@@ -5,7 +5,7 @@ import os.path
 from loguru import logger
 from tqdm import tqdm
 
-from datatrove.io import get_datafolder, get_file
+from datatrove.io import get_datafolder, open_file
 from datatrove.utils.stats import PipelineStats
 
 
@@ -34,7 +34,7 @@ def main():
         with stats_folder.open(file, "rt") as f:
             stats.append(PipelineStats.from_json(json.load(f)))
     merged = sum(tqdm(stats), start=PipelineStats())
-    with get_file(path, mode="wt") as f:
+    with open_file(path, mode="wt") as f:
         merged.save_to_disk(f)
     logger.info(f"Processing complete. Results saved to {path}.")
     logger.info(merged)


### PR DESCRIPTION
We can now filter using any fastText model. Arguments are url to download the model and required labels with a minimum score
Example:
```python
FastTextClassifierFilter(
    model_url="hf://allenai/dolma-jigsaw-fasttext-bigrams-nsfw/model.bin", 
    filter_labels=("non-toxic", 0.5),
    save_labels_in_metadata=True
)
```