### PR TITLE
Re-enable `datasets` test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ io = [
   "pyarrow",
   "python-magic",
   "warcio",
-  "datasets"
+  "datasets>=2.18.0"
 ]
 s3 = [
   "s3fs>=2023.12.2",

--- a/src/datatrove/pipeline/readers/huggingface.py
+++ b/src/datatrove/pipeline/readers/huggingface.py
@@ -52,7 +52,7 @@ class HuggingFaceDatasetReader(BaseReader):
         return document
 
     def run(self, data: DocumentsPipeline = None, rank: int = 0, world_size: int = 1) -> DocumentsPipeline:
-        from datasets import load_dataset
+        from datasets import load_dataset  # type: ignore
 
         if data:
             yield from data

--- a/tests/pipeline/test_hf_reader.py
+++ b/tests/pipeline/test_hf_reader.py
@@ -1,14 +1,15 @@
 import unittest
 
+from datatrove.pipeline.readers import HuggingFaceDatasetReader
+
 from ..utils import require_datasets
 
 
 @require_datasets
 class TestHuggingFaceReader(unittest.TestCase):
     def test_read_dataset(self):
-        # reader = HuggingFaceDatasetReader(
-        #     "truthful_qa", dataset_options={"name": "generation", "split": "validation"}, text_key="question"
-        # )
-        # data = list(reader())
-        # assert len(data) == 817
-        pass
+        reader = HuggingFaceDatasetReader(
+            "truthful_qa", dataset_options={"name": "generation", "split": "validation"}, text_key="question"
+        )
+        data = list(reader())
+        assert len(data) == 817


### PR DESCRIPTION
The latest `datasets` release supports `fsspec>=2.12.0`, so the `HuggingFaceDatasetReader` test can be re-enabled.