### PR TITLE
Fix `c4_qualiter_filter` curly brackets detection error

### DIFF
--- a/src/datatrove/pipeline/filters/c4_quality_filter.py
+++ b/src/datatrove/pipeline/filters/c4_quality_filter.py
@@ -53,7 +53,7 @@ class C4QualityFilter(BaseFilter):
         if len(lines) < self.min_lines:
             return False, f"< {self.min_lines} lines"
 
-        if "{" or "}" in doc.text:
+        if "{" in doc.text or "}" in doc.text:
             return False, "curly brackets"
 
         if self.lorem_ipsum.search(doc.text):


### PR DESCRIPTION
The original implementation use `if "{" or "}" in doc.text:` to filter the curly bracket
which actually will always produce `True`, so all document will be filtered.

Quick fix: use `if "{" in doc.text or "}" in doc.text:` instead.