### PR TITLE
Bug fix: when file is empty

### DIFF
--- a/src/datatrove/pipeline/dedup/minhash.py
+++ b/src/datatrove/pipeline/dedup/minhash.py
@@ -152,6 +152,8 @@ def read_sigs(
         index_file: is index file
     """
     with file as f:
+        if f.size == 0:
+            yield None
         seek_to_start(f, min_hash, config, index_file)
         last = None
         for data in read_tuples_from_file(


### PR DESCRIPTION
This may raise error when running `seek_to_start` func with file size = 0