### PR TITLE
update Trafilatura version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ processing = [
     "inscriptis",
 #    "readability-lxml @ git+https://github.com/huggingface/python-readability.git@speedup",
     "tldextract",
-    "trafilatura",
+    "trafilatura>=1.8.0",
     "tokenizers",
 ]
 quality = [


### PR DESCRIPTION
Accepting this PR closes issue https://github.com/huggingface/datatrove/issues/55 by using the newest (Apache-licensed) version of Trafilatura.