### PR TITLE
Minor Terminology and Documentation Updates for Local Tokenizer Loading

### DIFF
--- a/examples/tokenize_from_hf_to_s3.py
+++ b/examples/tokenize_from_hf_to_s3.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
                 output_folder=WORKING_DIR,
                 local_working_dir=LOCAL_WORKING_DIR,
                 save_filename=f"{DATASET_NAME}_tokenized",
-                tokenizer_name=args.tokenizer,
+                tokenizer_name_or_path=args.tokenizer,
             ),
         ],
         # If you have a very small dataset, feel free to set this to "1" and remove the merge_executor

--- a/src/datatrove/pipeline/dedup/exact_substrings.py
+++ b/src/datatrove/pipeline/dedup/exact_substrings.py
@@ -44,16 +44,16 @@ class ESDatasetToSequence(PipelineStepWithTokenizer):
 
     Args:
         output_folder: folder where sequences are saved
-        tokenizer_name: name of tokenizer as in HF tokenizers.
+        tokenizer_name_or_path: name or path of tokenizer as in HF tokenizers.
     """
 
     type = "🫂 - DEDUP"
     name = "🪞 - exact-substrings stage 1"
 
-    def __init__(self, output_folder: DataFolderLike, tokenizer_name: str = "gpt2"):
+    def __init__(self, output_folder: DataFolderLike, tokenizer_name_or_path: str = "gpt2"):
         super().__init__()
         self.output_folder = get_datafolder(output_folder)
-        self.tokenizer_name = tokenizer_name
+        self.tokenizer_name_or_path = tokenizer_name_or_path
 
     def save_sizes(self, doc_lens: list[int], rank: int):
         """Saves the byte sizes of each doc in a file.
@@ -153,13 +153,13 @@ class ESRangeRemover(PipelineStepWithTokenizer):
     def __init__(
         self,
         sequence_folder: DataFolderLike,
-        tokenizer_name: str = "gpt2",
+        tokenizer_name_or_path: str = "gpt2",
         min_doc_words: int = 50,
         language: str = "english",
     ):
         super().__init__()
         self.sequence_folder = get_datafolder(sequence_folder)
-        self.tokenizer_name = tokenizer_name
+        self.tokenizer_name_or_path = tokenizer_name_or_path
         self.min_doc_words = min_doc_words
         self.sequence_bytes_offset = None
         self.dup_ranges = None

--- a/src/datatrove/pipeline/tokens/counter.py
+++ b/src/datatrove/pipeline/tokens/counter.py
@@ -9,7 +9,7 @@ class TokensCounter(PipelineStepWithTokenizer):
         It doesn't save the tokenized documents, only the token count.
 
     Args:
-        tokenizer_name (str): the name of the tokenizer to use, from the HuggingFace tokenizers library.
+        tokenizer_name_or_path (str): the name or path of the tokenizer to use, from the HuggingFace tokenizers library or a local file.
         count_eos_token (bool): whether to count the EOS token on each document.
     """
 
@@ -18,19 +18,20 @@ class TokensCounter(PipelineStepWithTokenizer):
 
     def __init__(
         self,
-        tokenizer_name: str = "gpt2",  # tokenizer to use, from HF
+        tokenizer_name_or_path: str = "gpt2",  # tokenizer to use, from HF or a local file path
         count_eos_token: bool = False,  # whether to count the EOS token on each document
         overwrite: bool = True,  # re-tokenize and recompute nb of tokens even if they are already in metadata["tokens_count"]
     ):
         """
+        Initializes the token counting pipeline step.
 
         Args:
-            tokenizer_name: tokenizer to use (from HF)
-            count_eos_token: whether to count EOS tokens as well (basically +1 per document)
-            overwrite: re-tokenize and recompute nb of tokens even if they are already in metadata["tokens_count"]
+            tokenizer_name_or_path: Name or path of tokenizer to use (from HF or local).
+            count_eos_token: Whether to include the EOS token in the token count per document. (basically +1 per document)
+            overwrite: Whether to re-tokenize and recompute the number of tokens even if they are already stored in metadata["tokens_count"]
         """
         super().__init__()
-        self.tokenizer_name = tokenizer_name
+        self.tokenizer_name_or_path = tokenizer_name_or_path
         self.count_eos_token = count_eos_token
         self.overwrite = overwrite
 
@@ -43,6 +44,7 @@ class TokensCounter(PipelineStepWithTokenizer):
           world_size: int:  (Default value = 1)
 
         Returns:
+          DocumentsPipeline: The pipeline with updated documents, each having a new or updated `token_count` in its metadata.
 
         """
         for document in data:

--- a/src/datatrove/pipeline/tokens/merger.py
+++ b/src/datatrove/pipeline/tokens/merger.py
@@ -115,11 +115,11 @@ class DocumentTokenizerMerger(PipelineStep):
             else None
         )
 
-        tokenizer_name = None
+        tokenizer_name_or_path = None
         if self.save_final_metadata:
             if self.input_folder.isfile(f"{datafiles[0]}.metadata"):
                 with self.input_folder.open(f"{datafiles[0]}.metadata", "rt") as f:
-                    tokenizer_name = f.read().splitlines()[0]
+                    tokenizer_name_or_path = f.read().splitlines()[0]
 
         ordering = self.get_ordering(doc_ends)
 
@@ -129,7 +129,7 @@ class DocumentTokenizerMerger(PipelineStep):
             filename=f"{file_ct:03d}_{self.save_filename}.ds",
             save_loss_metadata=self.save_loss_metadata,
             upload_block_size=self.upload_block_size,
-            tokenizer_name=tokenizer_name,
+            tokenizer_name_or_path=tokenizer_name_or_path,
             save_final_metadata=self.save_final_metadata,
         )
         for input_file_id in tqdm(
@@ -145,7 +145,7 @@ class DocumentTokenizerMerger(PipelineStep):
                     filename=f"{file_ct:03d}_{self.save_filename}.ds",
                     save_loss_metadata=self.save_loss_metadata,
                     upload_block_size=self.upload_block_size,
-                    tokenizer_name=tokenizer_name,
+                    tokenizer_name_or_path=tokenizer_name_or_path,
                     save_final_metadata=self.save_final_metadata,
                 )
             # copy tokens and loss

--- a/src/datatrove/pipeline/tokens/tokenizer.py
+++ b/src/datatrove/pipeline/tokens/tokenizer.py
@@ -60,7 +60,7 @@ class TokenizedFile:
         save_index: bool = True,
         save_loss_metadata: bool = False,
         upload_block_size: int | None = None,
-        tokenizer_name: str | None = None,
+        tokenizer_name_or_path: str | None = None,
         save_final_metadata: bool = False,
     ):
         self.output_folder = get_datafolder(output_folder)
@@ -70,7 +70,7 @@ class TokenizedFile:
         self.upload_block_size = upload_block_size
         self.write_idx = 0
         self.doc_ends = []
-        self.tokenizer_name = tokenizer_name
+        self.tokenizer_name_or_path = tokenizer_name_or_path
         self.save_final_metadata = save_final_metadata
 
         self.tokens_file = self.output_folder.open(self.filename, mode="wb", block_size=upload_block_size)
@@ -195,7 +195,7 @@ class TokenizedFile:
                 destination,
                 save_loss_metadata=self.save_loss_metadata,
                 upload_block_size=self.upload_block_size,
-                tokenizer_name=self.tokenizer_name,
+                tokenizer_name_or_path=self.tokenizer_name_or_path,
                 save_final_metadata=self.save_final_metadata,
             )
             logger.info(f"Shuffling in {destination}...")
@@ -221,7 +221,7 @@ class TokenizedFile:
                         destination,
                         save_loss_metadata=self.save_loss_metadata,
                         upload_block_size=self.upload_block_size,
-                        tokenizer_name=self.tokenizer_name,
+                        tokenizer_name_or_path=self.tokenizer_name_or_path,
                         save_final_metadata=self.save_final_metadata,
                     )
                     logger.info(f"Shuffling in {destination}...")
@@ -239,7 +239,7 @@ class TokenizedFile:
             token_count (int): the token count to save (Default value = -1)
             filename: str:  (Default value = None)
         """
-        tokenizer_name = self.tokenizer_name
+        tokenizer_name = self.tokenizer_name_or_path
         if not tokenizer_name:
             tokenizer_name = "Unknown Tokenizer"
         if filename is None:
@@ -268,7 +268,7 @@ class DocumentTokenizer(PipelineStepWithTokenizer):
         local_working_dir (str | None): a local working directory to use for temporary files (before internal shuffling)
             if None we shuffle in output_folder (can be very slow if it's a remote location)
         save_filename (str): the filename to use for the final tokenized files (default: None – use the default filename)
-        tokenizer_name (str): the name of the tokenizer to use, from the HuggingFace tokenizers library (default: "gpt2")
+        tokenizer_name_or_path (str): the name or path of the tokenizer to use, from the HuggingFace tokenizers library (default: "gpt2")
         eos_token (str): whether to add the EOS token after each document (default: "<|endoftext|>")
         save_loss_metadata (bool): save the loss information (default: False)
         shuffle (bool): whether to shuffle documents in the dataset (default: True)
@@ -288,7 +288,7 @@ class DocumentTokenizer(PipelineStepWithTokenizer):
         output_folder: DataFolderLike,
         local_working_dir: DataFolderLike | None = None,
         save_filename: str = None,  # if defined, the final output filename will be this
-        tokenizer_name: str = "gpt2",  # tokenizer to use, from HF
+        tokenizer_name_or_path: str = "gpt2",  # tokenizer to use, from HF or a local
         eos_token: str = "<|endoftext|>",  # whether to add the EOS token after each document
         save_loss_metadata: bool = False,  # save the loss information
         shuffle: bool = True,  # whether to shuffle documents in the dataset,
@@ -310,7 +310,7 @@ class DocumentTokenizer(PipelineStepWithTokenizer):
                 "local_working_dir is not set and output folder is not local. This may slow down the process."
             )
         self.save_filename = save_filename
-        self.tokenizer_name = tokenizer_name
+        self.tokenizer_name_or_path = tokenizer_name_or_path
         self.eos_token = eos_token
         self.save_loss_metadata = save_loss_metadata
         self.shuffle = shuffle
@@ -358,7 +358,7 @@ class DocumentTokenizer(PipelineStepWithTokenizer):
             save_index=not self.shuffle,
             save_loss_metadata=self.save_loss_metadata,
             upload_block_size=self.upload_block_size,
-            tokenizer_name=self.tokenizer_name,
+            tokenizer_name_or_path=self.tokenizer_name_or_path,
             save_final_metadata=self.save_final_metadata,
         )
         # tokenize document's text in batches to go faster – we compute loss values independently if needed

--- a/src/datatrove/utils/tokenization.py
+++ b/src/datatrove/utils/tokenization.py
@@ -25,16 +25,16 @@ class PipelineStepWithTokenizer(PipelineStep, ABC):
     def __init__(self):
         super().__init__()
         self._tokenizer = None
-        self.tokenizer_name = None
+        self.tokenizer_name_or_path = None
         self._post_processor = None
         self.eos_token = None
 
     @property
     def tokenizer(self) -> "Tokenizer":
         if not self._tokenizer:
-            if not self.tokenizer_name:
-                raise ValueError("self.tokenizer_name needs to be set!")
-            self._tokenizer: "Tokenizer" = load_tokenizer(self.tokenizer_name)
+            if not self.tokenizer_name_or_path:
+                raise ValueError("self.tokenizer_name_or_path needs to be set!")
+            self._tokenizer: "Tokenizer" = load_tokenizer(self.tokenizer_name_or_path)
             if self._post_processor:
                 self._tokenizer.post_processor = self._post_processor
             elif self.eos_token:


### PR DESCRIPTION
I've been closely monitoring the DataTrove project and utilizing it in my workflow due to its efficient pipelining capabilities. Thanks for all the hard work on this project. Really appreciate it.

Given our environment's restriction on external internet access, the ability to load tokenizers from local files rather than exclusively from Hugging Face (HF) is crucial for us. I was delighted to discover that [recent update](https://github.com/huggingface/datatrove/commit/b98ef1c0abfd87db163b853a39516e4fa5035a9e)s have added the capability to load tokenizers locally.

Although I had prepared to contribute this specific feature, upon noticing its implementation, I opted to make some supplementary updates instead. These include renaming `tokenizer_name` to `tokenizer_name_or_path` and refining the related documentation to better align with the new functionality.

I welcome any feedback or suggestions for further refinements. Thank you for your ongoing efforts to enhance DataTrove.