### PR TITLE
Fix: Handle Non-dict Objects in to_dict Without Errors

### DIFF
--- a/src/datatrove/utils/stats.py
+++ b/src/datatrove/utils/stats.py
@@ -45,7 +45,7 @@ class MetricStatsDict(defaultdict):
         return ", ".join(f"{key}: {stats}" for key, stats in self.items())
 
     def to_dict(self):
-        return {a: b.to_dict() for a, b in self.items()}
+        return {a: (b.to_dict() if hasattr(b, "to_dict") else b) for a, b in self.items()}
 
 
 class Stats:


### PR DESCRIPTION
Ran into a bug where our to_dict method in stats.py would crash if it hit an int or something without a to_dict method. 
### error msg
``` error msg
/lib/python3.11/site-packages/datatrove/utils/stats.py", line 52, in to_dict
    t[a] = b.to_dict()
           ^^^^^^^^^
AttributeError: 'int' object has no attribute 'to_dict'
```

### sample data
```sample data
[
    {
        "name": "\ud83d\udcd6 - READER: \ud83d\udcd2 Parquet",
        "time_stats": {
            "total": 13.128175735473633,
            "mean": 13.128175735473633,
            "unit": "batch",
            "total_human": "13 seconds",
            "mean_human": "13 seconds and 128.18 milliseconds",
            "std_dev_human": "0 milliseconds",
            "min_human": "13 seconds and 128.18 milliseconds",
            "max_human": "13 seconds and 128.18 milliseconds"
        },
        "stats": {
            "input_files": 1,  # <— THIS CASE
            "doc_len": {
                "total": 177830,
                "n": 49,
                "mean": 3629.183673469389,
                "variance": 15571471.153061228,
                "std_dev": 3946.070343146613,
                "min": 39,
                "max": 18169
            },
            "documents": {
                "total": 48,
                "mean": 48.0,
                "unit": "input_file"
            }
        }
    },
…
]
```

Crashes with an AttributeError when it hits basic data types (like our friend, the integer).

The Fix:
- Added a quick check to only call to_dict() if the object actually has it. If not, just return the object as is.
- Now it handles int, floats and whatever else doesn't play nice with to_dict.