### PR TITLE
add requeue and QOS slurm options

### DIFF
--- a/src/datatrove/executor/slurm.py
+++ b/src/datatrove/executor/slurm.py
@@ -249,7 +249,7 @@ class SlurmPipelineExecutor(PipelineExecutor):
         # create the actual sbatch script
         launch_file_contents = self.get_launch_file_contents(
             self.get_sbatch_args(max_array),
-            f"srun -l python -m datatrove.tools.launch_pickled_pipeline {self.logging_dir.resolve_paths('executor.pik')}",
+            f"srun -l launch_pickled_pipeline {self.logging_dir.resolve_paths('executor.pik')}",
         )
         # save it
         with self.logging_dir.open("launch_script.slurm", "w") as launchscript_f:

--- a/src/datatrove/executor/slurm.py
+++ b/src/datatrove/executor/slurm.py
@@ -110,7 +110,7 @@ class SlurmPipelineExecutor(PipelineExecutor):
         requeue_signals: tuple[str] | None = ("SIGUSR1",),
         mail_type: str = "ALL",
         mail_user: str = None,
-        requeue: bool = True
+        requeue: bool = True,
     ):
         super().__init__(pipeline, logging_dir, skip_completed)
         self.tasks = tasks
@@ -284,11 +284,7 @@ class SlurmPipelineExecutor(PipelineExecutor):
         # this one we actually have to create as slurm will be writing here
         os.makedirs(self.slurm_logs_folder, exist_ok=True)
         slurm_logfile = os.path.join(self.slurm_logs_folder, "%A_%a.out")
-        if self.requeue:
-            self._sbatch_args["requeue"] = ""
-        if self.qos:
-            self._sbatch_args["qos"] = self.qos
-        return {
+        sbatch_args = {
             "cpus-per-task": self.cpus_per_task,
             "mem-per-cpu": f"{self.mem_per_cpu_gb}G",
             "partition": self.partition,
@@ -300,6 +296,11 @@ class SlurmPipelineExecutor(PipelineExecutor):
             **({"mail-type": self.mail_type, "mail-user": self.mail_user} if self.mail_user else {}),
             **self._sbatch_args,
         }
+        if self.requeue:
+            sbatch_args["requeue"] = ""
+        if self.qos:
+            sbatch_args["qos"] = self.qos
+        return sbatch_args
 
     def get_launch_file_contents(self, sbatch_args: dict, run_script: str) -> str:
         """


### PR DESCRIPTION
1. Not all clusters support QOS and requeue options so we make them optional. 
2. `launch_pickled_pipeline` might not work all the time (e.g. if you use a local fork of datatrove)