### PR TITLE
Optimize URLFilter and add option to disable integrated wordlists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ processing = [
     "tokenizers",
     "ftfy",
     "fasteners",
-    "xxhash"
+    "xxhash",
+    "pyahocorasick"
 ]
 decont = [
     "lighteval>=0.3.0"

--- a/src/datatrove/pipeline/filters/url_filter.py
+++ b/src/datatrove/pipeline/filters/url_filter.py
@@ -56,8 +56,8 @@ class URLFilter(BaseFilter):
         use_integrated_lists: bool = True,
         exclusion_writer: DiskWriter = None,
     ):
-        from tldextract import TLDExtract
         import ahocorasick
+        from tldextract import TLDExtract
 
         super().__init__(exclusion_writer)
         self.soft_word_threshold = soft_word_threshold

--- a/src/datatrove/pipeline/filters/url_filter.py
+++ b/src/datatrove/pipeline/filters/url_filter.py
@@ -27,7 +27,7 @@ def parse_list(line, do_normalize=True):
 
 def get_list(abs_path: str, file_name: str, extra: set = None, do_normalize: bool = True):
     with open(os.path.join(abs_path, file_name)) as f:
-        return parse_list(f, do_normalize).union(set(parse_list(extra, do_normalize)) if extra else set())
+        return parse_list(f, do_normalize).union(extra)
 
 
 class URLFilter(BaseFilter):
@@ -128,7 +128,7 @@ class URLFilter(BaseFilter):
             return False, "soft_blacklisted"
 
         normalized_space = normalize(url)
-        if next(self.banned_subwords_automaton.iter(normalized_space), False):
+        if self.banned_subwords and next(self.banned_subwords_automaton.iter(normalized_space), False):
             return False, "blacklisted_subword"
 
         return True

--- a/src/datatrove/pipeline/filters/url_filter.py
+++ b/src/datatrove/pipeline/filters/url_filter.py
@@ -43,7 +43,7 @@ class URLFilter(BaseFilter):
     """
 
     name = "😈 Url-filter"
-    _requires_dependencies = ["tldextract", "fasteners"]
+    _requires_dependencies = ["tldextract", "fasteners", ("ahocorasick", "pyahocorasick")]
 
     def __init__(
         self,
@@ -53,22 +53,32 @@ class URLFilter(BaseFilter):
         banned_words: Iterable = None,
         banned_subwords: Iterable = None,
         soft_banned_words: Iterable = None,
+        use_integrated_lists: bool = True,
         exclusion_writer: DiskWriter = None,
     ):
         from tldextract import TLDExtract
+        import ahocorasick
 
         super().__init__(exclusion_writer)
         self.soft_word_threshold = soft_word_threshold
-        self.block_listed_domains = extra_domains
-        self.block_listed_url = extra_urls
-        self.banned_words = banned_words
-        self.banned_subwords = banned_subwords
-        self.soft_banned_words = soft_banned_words
+        self.block_listed_domains = parse_list(extra_domains, do_normalize=False) if extra_domains else set()
+        self.block_listed_url = parse_list(extra_urls, do_normalize=False) if extra_urls else set()
+        self.banned_words = parse_list(banned_words) if banned_words else set()
+        self.banned_subwords = parse_list(banned_subwords) if banned_subwords else set()
+        self.soft_banned_words = parse_list(soft_banned_words) if soft_banned_words else set()
+        self.use_integrated_lists = use_integrated_lists
         self._downloaded = False
         self.tldextractor = TLDExtract()
 
+        self.banned_subwords_automaton = ahocorasick.Automaton(ahocorasick.STORE_INTS)
+        for word in self.banned_subwords:
+            self.banned_subwords_automaton.add_word(word, len(self.banned_subwords_automaton))
+
+        if not self.use_integrated_lists:
+            self.banned_subwords_automaton.make_automaton()
+
     def download_data(self):
-        if self._downloaded:
+        if self._downloaded or not self.use_integrated_lists:
             return
         download_dir = cached_assets_path(library_name="datatrove", namespace="filters", subfolder="url_filter")
         file_to_lock = os.path.join(download_dir, "url_filterblacklists.tar.gz")
@@ -88,6 +98,9 @@ class URLFilter(BaseFilter):
         self.banned_words = get_list(ASSETS_PATH, "banned_words.txt", self.banned_words)
         self.banned_subwords = get_list(ASSETS_PATH, "banned_subwords.txt", self.banned_subwords)
         self.soft_banned_words = get_list(ASSETS_PATH, "soft_banned_words.txt", self.soft_banned_words)
+        for word in self.banned_subwords:
+            self.banned_subwords_automaton.add_word(word, len(self.banned_subwords_automaton))
+        self.banned_subwords_automaton.make_automaton()
         self._downloaded = True
 
     def filter(self, document: Document) -> bool | tuple[bool, str]:
@@ -115,7 +128,7 @@ class URLFilter(BaseFilter):
             return False, "soft_blacklisted"
 
         normalized_space = normalize(url)
-        if any(word in normalized_space for word in self.banned_subwords):
+        if next(self.banned_subwords_automaton.iter(normalized_space), False):
             return False, "blacklisted_subword"
 
         return True

--- a/src/datatrove/pipeline/filters/url_filter.py
+++ b/src/datatrove/pipeline/filters/url_filter.py
@@ -25,7 +25,7 @@ def parse_list(line, do_normalize=True):
     return {normalize(x) if do_normalize else x.strip() for x in line if x[0] != "#"}
 
 
-def get_list(abs_path: str, file_name: str, extra: set = None, do_normalize: bool = True):
+def get_list(abs_path: str, file_name: str, extra: set, do_normalize: bool = True):
     with open(os.path.join(abs_path, file_name)) as f:
         return parse_list(f, do_normalize).union(extra)
 


### PR DESCRIPTION
This pull request makes two changes to URLFilter:
1. Replacing the naive subword search with a faster Aho-Corasick algorithm for multiple subwords.
2. Adding an argument that allows users to disable the usage of integrated block lists so they can supply their own lists instead.