### PR TITLE
Speedup json writer

### DIFF
--- a/examples/fineweb.py
+++ b/examples/fineweb.py
@@ -1,7 +1,8 @@
 """
-    This file contains the code used to process and create the
-    FineWeb dataset (https://huggingface.co/datasets/HuggingFaceFW/fineweb)
+This file contains the code used to process and create the
+FineWeb dataset (https://huggingface.co/datasets/HuggingFaceFW/fineweb)
 """
+
 from datatrove.executor.slurm import SlurmPipelineExecutor
 from datatrove.pipeline.dedup import MinhashDedupCluster, MinhashDedupFilter, MinhashDedupSignature
 from datatrove.pipeline.dedup.minhash import MinhashConfig, MinhashDedupBuckets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ io = [
   "pyarrow",
   "python-magic",
   "warcio",
-  "datasets>=2.18.0"
+  "datasets>=2.18.0",
+  "orjson"
 ]
 s3 = [
   "s3fs>=2023.12.2",

--- a/src/datatrove/pipeline/readers/jsonl.py
+++ b/src/datatrove/pipeline/readers/jsonl.py
@@ -1,5 +1,5 @@
-import json
-from json import JSONDecodeError
+import orjson
+from orjson import JSONDecodeError
 from typing import Callable, Literal
 
 from loguru import logger
@@ -68,7 +68,7 @@ class JsonlReader(BaseDiskReader):
                 for li, line in enumerate(f):
                     with self.track_time():
                         try:
-                            document = self.get_document_from_dict(json.loads(line), filepath, li)
+                            document = self.get_document_from_dict(orjson.loads(line), filepath, li)
                             if not document:
                                 continue
                         except (EOFError, JSONDecodeError) as e:

--- a/src/datatrove/pipeline/readers/jsonl.py
+++ b/src/datatrove/pipeline/readers/jsonl.py
@@ -29,6 +29,7 @@ class JsonlReader(BaseDiskReader):
     """
 
     name = "🐿 Jsonl"
+    _requires_dependencies = ["orjson"]
 
     def __init__(
         self,

--- a/src/datatrove/pipeline/readers/jsonl.py
+++ b/src/datatrove/pipeline/readers/jsonl.py
@@ -1,8 +1,8 @@
-import orjson
-from orjson import JSONDecodeError
 from typing import Callable, Literal
 
+import orjson
 from loguru import logger
+from orjson import JSONDecodeError
 
 from datatrove.io import DataFolderLike
 from datatrove.pipeline.readers.base import BaseDiskReader

--- a/src/datatrove/pipeline/readers/jsonl.py
+++ b/src/datatrove/pipeline/readers/jsonl.py
@@ -1,8 +1,6 @@
 from typing import Callable, Literal
 
-import orjson
 from loguru import logger
-from orjson import JSONDecodeError
 
 from datatrove.io import DataFolderLike
 from datatrove.pipeline.readers.base import BaseDiskReader
@@ -63,6 +61,9 @@ class JsonlReader(BaseDiskReader):
         self.compression = compression
 
     def read_file(self, filepath: str):
+        import orjson
+        from orjson import JSONDecodeError
+
         with self.data_folder.open(filepath, "r", compression=self.compression) as f:
             try:
                 for li, line in enumerate(f):

--- a/src/datatrove/pipeline/writers/jsonl.py
+++ b/src/datatrove/pipeline/writers/jsonl.py
@@ -25,8 +25,11 @@ class JsonlWriter(DiskWriter):
         compression: str | None = "gzip",
         adapter: Callable = None,
     ):
-        super().__init__(output_folder, output_filename=output_filename, compression=compression, adapter=adapter, mode="wb")
+        super().__init__(
+            output_folder, output_filename=output_filename, compression=compression, adapter=adapter, mode="wb"
+        )
 
     def _write(self, document: dict, file_handler: IO, _filename: str):
         import orjson
+
         file_handler.write(orjson.dumps(document, option=orjson.OPT_APPEND_NEWLINE))

--- a/src/datatrove/pipeline/writers/jsonl.py
+++ b/src/datatrove/pipeline/writers/jsonl.py
@@ -1,4 +1,3 @@
-import json
 from typing import IO, Callable
 
 from datatrove.io import DataFolderLike
@@ -17,6 +16,7 @@ class JsonlWriter(DiskWriter):
 
     default_output_filename: str = "${rank}.jsonl"
     name = "🐿 Jsonl"
+    _requires_dependencies = ["orjson"]
 
     def __init__(
         self,
@@ -25,7 +25,8 @@ class JsonlWriter(DiskWriter):
         compression: str | None = "gzip",
         adapter: Callable = None,
     ):
-        super().__init__(output_folder, output_filename=output_filename, compression=compression, adapter=adapter)
+        super().__init__(output_folder, output_filename=output_filename, compression=compression, adapter=adapter, mode="wb")
 
     def _write(self, document: dict, file_handler: IO, _filename: str):
-        file_handler.write(json.dumps(document, ensure_ascii=False) + "\n")
+        import orjson
+        file_handler.write(orjson.dumps(document, option=orjson.OPT_APPEND_NEWLINE))


### PR DESCRIPTION
This pull request replaces the `json` standard library with a much more faster `orjson` library, speeding up JsonlWriter by about 5x on my machine, and about 2x for JsonlReader, roughly matching the numbers given in the [orjson's README](https://github.com/ijl/orjson#latency).