### PR TITLE
Migrate dedup to xxhash

### DIFF
--- a/src/datatrove/pipeline/base.py
+++ b/src/datatrove/pipeline/base.py
@@ -1,9 +1,8 @@
 from abc import ABC, abstractmethod
 from itertools import chain
-from typing import NoReturn
 
 from datatrove.data import Document, DocumentsPipeline
-from datatrove.utils._import_utils import _is_package_available
+from datatrove.utils._import_utils import check_required_dependencies
 from datatrove.utils.stats import Stats
 
 
@@ -29,14 +28,7 @@ class PipelineStep(ABC):
         """
         required_dependencies = chain.from_iterable(getattr(t, "_requires_dependencies", []) for t in cls.mro())
         if required_dependencies:
-            missing_dependencies: dict[str, str] = {}
-            for dependency in required_dependencies:
-                dependency = dependency if isinstance(dependency, tuple) else (dependency, dependency)
-                package_name, pip_name = dependency
-                if not _is_package_available(package_name):
-                    missing_dependencies[package_name] = pip_name
-            if missing_dependencies:
-                _raise_error_for_missing_dependencies(cls.__name__, missing_dependencies)
+            check_required_dependencies(cls.__name__, required_dependencies)
         return super().__new__(cls)
 
     def __init__(self):
@@ -125,26 +117,3 @@ class PipelineStep(ABC):
 
         """
         return self.run(data, rank, world_size)
-
-
-def _raise_error_for_missing_dependencies(step_name: str, dependencies: dict[str, str]) -> NoReturn:
-    """Helper to raise an ImportError for missing dependencies and prompt the user to install said dependencies
-
-    Args:
-        step_name: str
-            The name of the step
-        dependencies: dict[str, str]
-            The missing dependencies
-
-    """
-    dependencies = dict(sorted(dependencies.items()))
-    package_names = list(dependencies)
-    if len(dependencies) > 1:
-        package_names = (
-            f"{','.join('`' + package_name + '`' for package_name in package_names[:-1])} and `{package_names[-1]}`"
-        )
-    else:
-        package_names = f"`{package_names[0]}`"
-    raise ImportError(
-        f"Please install {package_names} to use {step_name} (`pip install {' '.join(list(dependencies.values()))}`)."
-    )

--- a/src/datatrove/pipeline/decont/n_grams.py
+++ b/src/datatrove/pipeline/decont/n_grams.py
@@ -45,6 +45,7 @@ class NGramsDecontConfig:
     find_query_ngrams: bool = False  # enable to also check for matches in n-grams containing only the input/prompt
     find_overlap_ngrams: bool = True  # will also find matches for n-grams containing BOTH input and query
     norm_config: TextNormConfig = field(default_factory=TextNormConfig)
+    hash_config: HashConfig = field(default_factory=lambda: DEFAULT_HASH_CONFIG)
 
 
 DEFAULT_NGRAMS_DECONT_CONFIG = NGramsDecontConfig()
@@ -74,7 +75,6 @@ class NGramsDecontIndexer(PipelineStep):
         lighteval_tasks: str | list[str] | None = None,  # list in the format suite|task or path to one such list
         custom_lighteval_tasks: str | None = None,
         config: NGramsDecontConfig = DEFAULT_NGRAMS_DECONT_CONFIG,
-        hash_config: HashConfig = DEFAULT_HASH_CONFIG,
         language: str = "english",
     ):
         super().__init__()
@@ -91,7 +91,7 @@ class NGramsDecontIndexer(PipelineStep):
         self.custom_lighteval_tasks = custom_lighteval_tasks
         self.config = config
         self.language = language
-        self.hash_func = create_hash_func(hash_config)
+        self.hash_func = create_hash_func(self.config.hash_config)
 
     def compute_hashes(self, label: str, query: str | None = None) -> list[int]:
         from nltk import ngrams
@@ -185,7 +185,6 @@ class NGramsDecontFilter(BaseFilter):
         self,
         index_folder: DataFolderLike,
         config: NGramsDecontConfig = DEFAULT_NGRAMS_DECONT_CONFIG,
-        hash_config: HashConfig = DEFAULT_HASH_CONFIG,
         exclusion_writer: DiskWriter = None,
         language: str = "english",
     ):
@@ -195,7 +194,7 @@ class NGramsDecontFilter(BaseFilter):
         self.exclusion_writer = exclusion_writer
         self.language = language
         self._index_hashes = None
-        self.hash_func = create_hash_func(hash_config)
+        self.hash_func = create_hash_func(self.config.hash_config)
 
     def load_index_hashes(self):
         def load_index_from_file(file):

--- a/src/datatrove/pipeline/dedup/bloom_filter.py
+++ b/src/datatrove/pipeline/dedup/bloom_filter.py
@@ -1,6 +1,6 @@
 import contextlib
 import math
-from dataclasses import replace
+from dataclasses import dataclass, field
 
 import numpy as np
 
@@ -8,15 +8,46 @@ from datatrove.data import Document, DocumentsPipeline
 from datatrove.io import DataFolderLike, get_datafolder
 from datatrove.pipeline.base import PipelineStep
 from datatrove.pipeline.writers.disk_base import DiskWriter
-from datatrove.utils.hashing import DEFAULT_HASH_CONFIG, HashConfig, create_hash_func
+from datatrove.utils.hashing import HashConfig, create_hash_func
 from datatrove.utils.logging import logger
-from datatrove.utils.text import DEF_TEXT_NORM_CONFIG, TextNormConfig, simplify_text
+from datatrove.utils.text import TextNormConfig, simplify_text
 from datatrove.utils.typeshelper import StatHints
 
 
 # http://en.wikipedia.org/wiki/Mersenne_prime
 _mersenne_prime = np.uint64((1 << 61) - 1)
 MAX_HASH = 1 << 32 - 1
+
+
+@dataclass
+class BloomFilterConfig:
+    """
+    m_bytes: bloom filter size in bytes (actual size x8 bigger)
+    k: number of hashes
+    expected_elements: expected number of elements, aka
+        shingles.
+    duplicate_threshold: above which documents are considered as
+        duplicated
+    n_grams: n_grams to use
+    seed: seed
+    """
+
+    m_bytes: int
+    k: int = None
+    expected_elements: int = None
+    duplicate_threshold: float = 0.8
+    n_grams: int = 13
+    seed: int = 0
+    norm_config: TextNormConfig = field(default_factory=TextNormConfig)
+    hash_config: HashConfig = field(default_factory=lambda: HashConfig(precision=32))
+
+    @property
+    def m(self):  # (self.m + 7) // 8  # size in bytes
+        return self.m_bytes * 8
+
+    def __post_init__(self):
+        if self.k is None:
+            self.k = get_optimal_k(self.m, expected_elements=self.expected_elements)
 
 
 def get_optimal_k(size_in_bytes: int, expected_elements: int) -> int:
@@ -36,14 +67,6 @@ class SingleBloomFilter(PipelineStep):
 
     Args:
         output_folder: output folder: local or on S3
-        m_bytes: bloom filter size in bytes (actual size x8 bigger)
-        k: number of hashes
-        expected_elements: expected number of elements, aka
-            shingles.
-        duplicate_threshold: above which documents are considered as
-            duplicated
-        n_grams: n_grams to use
-        seed: seed
         save_bloom_filter: if true saves bloom filter for later use
         exclusion_writer: saves duplicated data
     """
@@ -55,41 +78,28 @@ class SingleBloomFilter(PipelineStep):
     def __init__(
         self,
         output_folder: DataFolderLike,
-        m_bytes: int,
-        k: int = None,
-        expected_elements: int = None,
-        duplicate_threshold: float = 0.8,
-        n_grams: int = 13,
-        seed: int = 0,
-        norm_config: TextNormConfig = DEF_TEXT_NORM_CONFIG,
-        hash_config: HashConfig = replace(DEFAULT_HASH_CONFIG, precision=32),
+        config: BloomFilterConfig,
         save_bloom_filter: bool = False,
         exclusion_writer: DiskWriter = None,
         language: str = "english",
     ):
         super().__init__()
         self.output_folder = get_datafolder(output_folder)
-        self.m_bytes = m_bytes  # size in bits
-        self.m = m_bytes * 8  # (self.m + 7) // 8  # size in bytes
-        self.k = k if k else get_optimal_k(self.m, expected_elements=expected_elements)
-        self.duplicate_threshold = duplicate_threshold
-        self.n_grams = n_grams
-        self.bit_vector = bytearray(([0] * self.m_bytes))
+        self.config = config
+        self.bit_vector = bytearray(([0] * self.config.m_bytes))
         self.save_bloom_filter = save_bloom_filter
         self.exclusion_writer = exclusion_writer
-        self.norm_config = norm_config
         # TODO: Add support for 64-bit
-        assert hash_config.precision == 32, "Bloom filter only supports 32-bit hashes"
-        self.hash_fc = create_hash_func(hash_config)
-        assert self.m < MAX_HASH
+        assert self.config.hash_config.precision == 32, "Bloom filter only supports 32-bit hashes"
+        self.hash_fc = create_hash_func(self.config.hash_config)
+        assert self.config.m < MAX_HASH
 
-        self.seed = seed
         self.total_shingles = 0
         self._parameters = None
 
-        assert self.m_bytes < MAX_HASH, f"{MAX_HASH=} is smaller than {self.m_bytes=}"
-        if expected_elements:
-            fp = get_false_positive_prob(self.m_bytes, n=expected_elements, k=self.k)
+        assert self.config.m_bytes < MAX_HASH, f"{MAX_HASH=} is smaller than {self.config.m_bytes=}"
+        if self.config.expected_elements:
+            fp = get_false_positive_prob(self.config.m_bytes, n=self.config.expected_elements, k=self.config.k)
             if fp > 0.05:
                 logger.warning(f"False probability = {fp:.3}")
             else:
@@ -109,10 +119,10 @@ class SingleBloomFilter(PipelineStep):
                 random parameters for the hash functions.
         """
         if not self._parameters:
-            gen = np.random.RandomState(self.seed)
+            gen = np.random.RandomState(self.config.seed)
             self._parameters = (
-                gen.randint(1, _mersenne_prime, dtype=np.uint64, size=(1, self.k)),
-                gen.randint(0, _mersenne_prime, dtype=np.uint64, size=(1, self.k)),
+                gen.randint(1, _mersenne_prime, dtype=np.uint64, size=(1, self.config.k)),
+                gen.randint(0, _mersenne_prime, dtype=np.uint64, size=(1, self.config.k)),
             )
         return self._parameters
 
@@ -125,7 +135,7 @@ class SingleBloomFilter(PipelineStep):
         return np.fromiter(
             [
                 self.hash_fc(" ".join(x))
-                for x in ngrams(word_tokenize(simplify_text(text, self.norm_config)), self.n_grams)
+                for x in ngrams(word_tokenize(simplify_text(text, self.config.norm_config)), self.config.n_grams)
             ],
             dtype=np.uint64,
         ).reshape((-1, 1))
@@ -133,7 +143,7 @@ class SingleBloomFilter(PipelineStep):
     def get_indexes(self, shingles: np.ndarray) -> list[list[int]]:
         """Get indexes for the shingles with the k hashing functions"""
         a, b = self.parameters
-        phv = np.bitwise_and((shingles * a + b) % _mersenne_prime, self.m_bytes)
+        phv = np.bitwise_and((shingles * a + b) % _mersenne_prime, self.config.m_bytes)
         return phv.tolist()
 
     def update_bf(self, indexes: list[int]):
@@ -150,7 +160,6 @@ class SingleBloomFilter(PipelineStep):
             mask = 1 << bit_index
             if (self.bit_vector[byte_index] & mask) == 0:
                 return False
-
         return True
 
     def step(self, doc: Document) -> bool:
@@ -172,7 +181,7 @@ class SingleBloomFilter(PipelineStep):
                 indexes_to_update.extend(indexes)
 
         self.update_bf(indexes_to_update)
-        if duplicate_shingles / len(shingles) > self.duplicate_threshold:
+        if duplicate_shingles / len(shingles) > self.config.duplicate_threshold:
             self.stat_update(StatHints.dropped)
             return False
         return True
@@ -194,5 +203,7 @@ class SingleBloomFilter(PipelineStep):
                     f.write(self.bit_vector)
 
         logger.info(f"{self.total_shingles=}")
-        logger.info(f"False probability = {get_false_positive_prob(self.m_bytes, n=self.total_shingles, k=self.k):.3}")
-        logger.info(f"Optimal K given total shingles = {get_optimal_k(self.m_bytes, self.total_shingles)}")
+        logger.info(
+            f"False probability = {get_false_positive_prob(self.config.m_bytes, n=self.total_shingles, k=self.config.k):.3}"
+        )
+        logger.info(f"Optimal K given total shingles = {get_optimal_k(self.config.m_bytes, self.total_shingles)}")

--- a/src/datatrove/pipeline/dedup/minhash.py
+++ b/src/datatrove/pipeline/dedup/minhash.py
@@ -453,7 +453,9 @@ class MinhashDedupCluster(PipelineStep):
         def parent(x):
             if x not in union_set or union_set[x] == x:
                 return x
-            return parent(union_set[x])
+            # Path Compression
+            union_set[x] = parent(union_set[x])
+            return union_set[x]
 
         with self.track_time():
             for dup_file in dup_files:

--- a/src/datatrove/pipeline/dedup/minhash.py
+++ b/src/datatrove/pipeline/dedup/minhash.py
@@ -391,11 +391,13 @@ class MinhashDedupBuckets(PipelineStep):
                             # write (file_id1, doc_id1, file_id2, doc_id2)
                             if last.is_from_index():
                                 # we can't actually write -1, so we use SENTINEL instead
-                                out_f.write(struct.pack("<4I", SENTINEL, SENTINEL, v.file_stem, v.doc_id))
+                                out_f.write(struct.pack("<4I", SENTINEL, SENTINEL, int(v.file_stem), v.doc_id))
                                 self.stat_update("index_match", "total_matches")
                             # if there isn't an index, or we are not only deduping in relation to the index
                             elif not index_files or not self.only_dedup_in_index:
-                                out_f.write(struct.pack("<4I", last.file_stem, last.doc_id, v.file_stem, v.doc_id))
+                                out_f.write(
+                                    struct.pack("<4I", int(last.file_stem), last.doc_id, int(v.file_stem), v.doc_id)
+                                )
                                 self.stat_update("total_matches")
                         elif out_index:
                             # new sig that isn't part of any index, save to our new index

--- a/src/datatrove/pipeline/dedup/minhash.py
+++ b/src/datatrove/pipeline/dedup/minhash.py
@@ -102,7 +102,7 @@ def read_sigs(
             return
         seek_to_start(f, min_hash, line_format, config.hash_config.struct_format)
         last = None
-        file_stem = Path(file.path).name.replace(".minhash.sig", "")
+        file_stem = Path(file.path).name.removesuffix(".minhash.sig")
         for data in read_tuples_from_file(f, line_format, lines_to_buffer=lines_to_buffer):
             sigdata = data if index_file else data[:-1]
             assert sigdata[0] >= min_hash and (

--- a/src/datatrove/pipeline/dedup/minhash.py
+++ b/src/datatrove/pipeline/dedup/minhash.py
@@ -43,7 +43,6 @@ class MinhashConfig:
         n_grams: n-grams size to use
         num_buckets: number of buckets to use
         hashes_per_bucket: number of hashes per bucket
-        use_64bit_hashes: use 64bit hashes. Uses 32bit hashes if `False`
         seed: random seed used to generate the hash function parameters. Should be the same on all workers to ensure they all have the same parameters
     """
 
@@ -56,11 +55,7 @@ class MinhashConfig:
     hash_config: HashConfig = field(default_factory=lambda: DEFAULT_HASH_CONFIG)
 
     def __str__(self):
-        return (
-            f"{self.n_grams}ng_{self.num_buckets}bs_{self.hashes_per_bucket}hs_"
-            # TODO: Add repr to hash_config
-            f"{self.hash_config}"
-        )
+        return f"{self.n_grams}ng_{self.num_buckets}bs_{self.hashes_per_bucket}hs_" f"{self.hash_config}"
 
 
 DEFAULT_MINHASH_CONFIG = MinhashConfig()

--- a/src/datatrove/pipeline/dedup/sentence_dedup.py
+++ b/src/datatrove/pipeline/dedup/sentence_dedup.py
@@ -170,7 +170,7 @@ def read_sigs(
     lines_to_buffer: int = 5,
 ) -> Generator[HashSig, None, None]:
     line_format = f"{config.hash_config.struct_format}IH" if not index_file else config.hash_config.struct_format
-    file_stem = Path(file.path).name.replace(ExtensionHelperSD.stage_1_signature, "")
+    file_stem = Path(file.path).name.removesuffix(ExtensionHelperSD.stage_1_signature)
     last = None
     with file as f:
         for data in read_tuples_from_file(f, line_format, lines_to_buffer=lines_to_buffer):

--- a/src/datatrove/pipeline/dedup/url_dedup.py
+++ b/src/datatrove/pipeline/dedup/url_dedup.py
@@ -6,7 +6,8 @@ import contextlib
 import heapq
 import struct
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from functools import partial
 from typing import BinaryIO, Callable, Generator
 
 import numpy as np
@@ -18,7 +19,7 @@ from datatrove.data import Document, DocumentsPipeline
 from datatrove.io import DataFolderLike, get_datafolder
 from datatrove.pipeline.base import PipelineStep
 from datatrove.utils.binaryio import read_np_from_file, read_tuples_from_file
-from datatrove.utils.text import xxhash64
+from datatrove.utils.hashing import DEFAULT_HASH_CONFIG, HashConfig, create_hash_func
 from datatrove.utils.typeshelper import ExtensionHelperSD, StatHints
 
 from ..writers.disk_base import DiskWriter
@@ -36,6 +37,7 @@ class UrlDedupConfig:
 
     url_normalizer: Callable[[str], str] | None = None
     document_priority: Callable[[Document], int] | None = None
+    hash_config: HashConfig = field(default_factory=lambda: DEFAULT_HASH_CONFIG)
 
 
 DEFAULT_URL_DEDUP_CONFIG = UrlDedupConfig()
@@ -60,8 +62,8 @@ class HashSig:
         )
 
 
-SIG_DTYPE = np.dtype([("hash", "<u8"), ("priority", "<u2"), ("doc", "<u4")])
-DUP_DTYPE = SIG_DTYPE[2]
+def get_sig_dtype(config: HashConfig) -> np.dtype:
+    return np.dtype([("hash", config.np_dtype), ("priority", "<u2"), ("doc", "<u4")])
 
 
 class UrlDedupSignature(PipelineStep):
@@ -77,7 +79,6 @@ class UrlDedupSignature(PipelineStep):
 
     type = "🫂 - DEDUPS"
     name = "💥 url-deduplication stage 1"
-    _requires_dependencies = ["xxhash"]
 
     def __init__(
         self,
@@ -93,15 +94,17 @@ class UrlDedupSignature(PipelineStep):
             logger.warning(f"Remember to also set the number of tasks of the finder block to {finder_workers=}!")
         self.finder_workers = finder_workers
         self.config = config
+        self.hash_fc = create_hash_func(self.config.hash_config)
 
     def save_hashes(self, rank: int, signatures):
-        priority_max = np.iinfo(SIG_DTYPE["priority"]).max
+        sig_dtype = get_sig_dtype(self.config.hash_config)
+        priority_max = np.iinfo(sig_dtype["priority"]).max
 
         # 0 will stay as is, so we can't use 0 as a priority
         assert all(
             sig[1] >= 1 and sig[1] <= priority_max for sig in signatures
         ), f"priority must be between 1 and {priority_max}"
-        signatures = np.array(signatures, dtype=SIG_DTYPE)
+        signatures = np.array(signatures, dtype=sig_dtype)
 
         # Ensure that the highest priority is always first
         signatures["priority"] = -signatures["priority"]
@@ -109,7 +112,7 @@ class UrlDedupSignature(PipelineStep):
         signatures["priority"] = -signatures["priority"]
 
         # Same code as in sentence_dedup
-        hashes_per_worker = np.iinfo(np.uint64).max // self.finder_workers
+        hashes_per_worker = self.config.hash_config.max // self.finder_workers
         left_idx = 0
         for hash_i in range(self.finder_workers):
             with self.output_folder.open(
@@ -137,8 +140,7 @@ class UrlDedupSignature(PipelineStep):
             self.config.url_normalizer(doc.metadata["url"]) if self.config.url_normalizer else doc.metadata["url"]
         )
         priority = self.config.document_priority(doc) if self.config.document_priority else 1
-        # We use xxhash as it's the fastest and we don't need cryptographic security
-        hashes = [(xxhash64(normalized_url), priority, doc_idx)]
+        hashes = [(self.hash_fc(normalized_url), priority, doc_idx)]
 
         return hashes
 
@@ -154,11 +156,12 @@ class UrlDedupSignature(PipelineStep):
 def read_sigs(
     file: AbstractBufferedFile,
     file_id: int,
+    hash_config: HashConfig,
     index_file: bool = False,
     lines_to_buffer: int = 5,
 ) -> Generator[HashSig, None, None]:
     last = None
-    line_format = "QHI" if not index_file else "Q"
+    line_format = f"{hash_config.struct_format}HI" if not index_file else hash_config.struct_format
     with file as f:
         for data in read_tuples_from_file(f, line_format, lines_to_buffer=lines_to_buffer):
             assert last is None or data[0] >= last, f"Hash order error. {f.tell()=}, {data[0]=}, {last=}"
@@ -226,6 +229,7 @@ class UrlFindDedups(PipelineStep):
                 read_sigs(
                     file,
                     file_i,
+                    self.config.hash_config,
                     lines_to_buffer=self.lines_to_buffer,
                 )
                 for file_i, file in enumerate(self.data_folder.open_files(sig_files))
@@ -238,6 +242,7 @@ class UrlFindDedups(PipelineStep):
                         read_sigs(
                             file,
                             len(sig_readers) + file_i,
+                            self.config.hash_config,
                             index_file=True,
                             lines_to_buffer=self.lines_to_buffer,
                         )
@@ -301,10 +306,10 @@ class UrlDedupFilter(PipelineStep):
         self.config = config
         self.exclusion_writer = exclusion_writer
 
-    def read_duplicates(self, file: BinaryIO) -> np.ndarray:
+    def read_duplicates(self, file: BinaryIO, dup_dtype: np.dtype) -> np.ndarray:
         """Helper function to read duplicates from a binary file storing (doc_id) as created by the second stage."""
         with file as f:
-            return read_np_from_file(f, dtype=DUP_DTYPE, is_local_file=self.data_folder.is_local())
+            return read_np_from_file(f, dtype=dup_dtype, is_local_file=self.data_folder.is_local())
 
     def run(self, data: DocumentsPipeline, rank: int = 0, world_size: int = 1):
         folders = self.data_folder.list_files(include_directories=True, recursive=False)
@@ -317,13 +322,15 @@ class UrlDedupFilter(PipelineStep):
 
         logger.info(f"Loading duplicate indexes from {len(files)} results files.")
 
-        all_dups = np.array([], dtype=DUP_DTYPE)
+        dup_dtype = get_sig_dtype(self.config.hash_config)[2]
+        all_dups = np.array([], dtype=dup_dtype)
         if files:
             with ThreadPoolExecutor() as pool:
+                read_partial = partial(self.read_duplicates, dup_dtype=dup_dtype)
                 all_dups = np.concatenate(
                     list(
                         tqdm(
-                            pool.map(self.read_duplicates, self.data_folder.open_files(files)),
+                            pool.map(read_partial, self.data_folder.open_files(files)),
                             total=len(files),
                         )
                     ),
@@ -332,7 +339,6 @@ class UrlDedupFilter(PipelineStep):
             all_dups.sort()
 
         logger.info("Loaded duplicate indexes.")
-
         dups_doc_i = 0
         with self.exclusion_writer if self.exclusion_writer else contextlib.nullcontext() as writer:
             with self.stats.time_stats:

--- a/src/datatrove/pipeline/dedup/url_dedup.py
+++ b/src/datatrove/pipeline/dedup/url_dedup.py
@@ -304,7 +304,7 @@ class UrlDedupFilter(PipelineStep):
     ):
         super().__init__()
         self.data_folder = get_datafolder(data_folder)
-        self.config = config or UrlDedupConfig
+        self.config = config or UrlDedupConfig()
         self.exclusion_writer = exclusion_writer
 
     def read_duplicates(self, file: BinaryIO, dup_dtype: np.dtype) -> np.ndarray:

--- a/src/datatrove/pipeline/dedup/url_dedup.py
+++ b/src/datatrove/pipeline/dedup/url_dedup.py
@@ -162,7 +162,7 @@ def read_sigs(
     last = None
     line_format = f"{hash_config.struct_format}HI" if not index_file else hash_config.struct_format
     with file as f:
-        file_stem = Path(f.path).name.replace(ExtensionHelperSD.stage_1_signature, "")
+        file_stem = Path(f.path).name.removesuffix(ExtensionHelperSD.stage_1_signature)
         for data in read_tuples_from_file(f, line_format, lines_to_buffer=lines_to_buffer):
             assert last is None or data[0] >= last, f"Hash order error. {f.tell()=}, {data[0]=}, {last=}"
             last = data[0]

--- a/src/datatrove/utils/_import_utils.py
+++ b/src/datatrove/utils/_import_utils.py
@@ -7,11 +7,6 @@ from typing import NoReturn
 ASSETS_PATH = os.path.join(importlib.resources.files(__package__.split(".")[0]), "assets")
 
 
-def guarded_import(step_name: str, package_name: str):
-    check_required_dependencies(step_name, [package_name])
-    return importlib.import_module(package_name)
-
-
 def check_required_dependencies(step_name: str, required_dependencies: list[str] | list[tuple[str, str]]):
     missing_dependencies: dict[str, str] = {}
     for dependency in required_dependencies:

--- a/src/datatrove/utils/_import_utils.py
+++ b/src/datatrove/utils/_import_utils.py
@@ -1,9 +1,49 @@
 import importlib.resources
 import os
 from functools import lru_cache
+from typing import NoReturn
 
 
 ASSETS_PATH = os.path.join(importlib.resources.files(__package__.split(".")[0]), "assets")
+
+
+def guarded_import(step_name: str, package_name: str):
+    check_required_dependencies(step_name, [package_name])
+    return importlib.import_module(package_name)
+
+
+def check_required_dependencies(step_name: str, required_dependencies: list[str] | list[tuple[str, str]]):
+    missing_dependencies: dict[str, str] = {}
+    for dependency in required_dependencies:
+        dependency = dependency if isinstance(dependency, tuple) else (dependency, dependency)
+        package_name, pip_name = dependency
+        if not _is_package_available(package_name):
+            missing_dependencies[package_name] = pip_name
+    if missing_dependencies:
+        _raise_error_for_missing_dependencies(step_name, missing_dependencies)
+
+
+def _raise_error_for_missing_dependencies(step_name: str, dependencies: dict[str, str]) -> NoReturn:
+    """Helper to raise an ImportError for missing dependencies and prompt the user to install said dependencies
+
+    Args:
+        step_name: str
+            The name of the step
+        dependencies: dict[str, str]
+            The missing dependencies
+
+    """
+    dependencies = dict(sorted(dependencies.items()))
+    package_names = list(dependencies)
+    if len(dependencies) > 1:
+        package_names = (
+            f"{','.join('`' + package_name + '`' for package_name in package_names[:-1])} and `{package_names[-1]}`"
+        )
+    else:
+        package_names = f"`{package_names[0]}`"
+    raise ImportError(
+        f"Please install {package_names} to use {step_name} (`pip install {' '.join(list(dependencies.values()))}`)."
+    )
 
 
 @lru_cache

--- a/src/datatrove/utils/hashes/sha1.py
+++ b/src/datatrove/utils/hashes/sha1.py
@@ -1,0 +1,26 @@
+import hashlib
+import struct
+
+
+def sha1_hash32(data: str):
+    """A 32-bit hash function based on SHA1.
+
+    Args:
+        data (bytes): the data to generate 32-bit integer hash from.
+
+    Returns:
+        int: an integer hash value that can be encoded using 32 bits.
+    """
+    return struct.unpack("<I", hashlib.sha1(data.encode("utf-8")).digest()[:4])[0]
+
+
+def sha1_hash64(data: str):
+    """A 64-bit hash function based on SHA1.
+
+    Args:
+        data (bytes): the data to generate 64-bit integer hash from.
+
+    Returns:
+        int: an integer hash value that can be encoded using 64 bits.
+    """
+    return struct.unpack("<Q", hashlib.sha1(data.encode("utf-8")).digest()[:8])[0]

--- a/src/datatrove/utils/hashes/xxhash.py
+++ b/src/datatrove/utils/hashes/xxhash.py
@@ -1,0 +1,9 @@
+import xxhash
+
+
+def xxhash32(data: str):
+    return xxhash.xxh32_intdigest(data)
+
+
+def xxhash64(data: str):
+    return xxhash.xxh64_intdigest(data)

--- a/src/datatrove/utils/hashing.py
+++ b/src/datatrove/utils/hashing.py
@@ -38,7 +38,6 @@ class HashConfig:
 
 
 def create_hash_func(config: HashConfig) -> Callable[[str], int]:
-    # TODO: Check requirements for xxhash
     if config.hash_fc == "sha1":
         return sha1_hash32 if config.precision == 32 else sha1_hash64
     elif config.hash_fc == "xxhash":

--- a/src/datatrove/utils/hashing.py
+++ b/src/datatrove/utils/hashing.py
@@ -50,6 +50,3 @@ def create_hash_func(config: HashConfig) -> Callable[[str], int]:
         return xxhash32 if config.precision == 32 else xxhash64
     else:
         raise ValueError(f"Unknown {config.hash_fc=}")
-
-
-DEFAULT_HASH_CONFIG = HashConfig()

--- a/src/datatrove/utils/hashing.py
+++ b/src/datatrove/utils/hashing.py
@@ -1,0 +1,82 @@
+# https://github.com/ekzhu/datasketch/blob/master/datasketch/hashfunc.py
+import hashlib
+import struct
+from dataclasses import dataclass
+from typing import Callable, Literal
+
+import numpy as np
+import xxhash
+
+from datatrove.utils._import_utils import guarded_import
+
+
+def sha1_hash32(data: str):
+    """A 32-bit hash function based on SHA1.
+
+    Args:
+        data (bytes): the data to generate 32-bit integer hash from.
+
+    Returns:
+        int: an integer hash value that can be encoded using 32 bits.
+    """
+    return struct.unpack("<I", hashlib.sha1(data.encode("utf-8")).digest()[:4])[0]
+
+
+def sha1_hash64(data: str):
+    """A 64-bit hash function based on SHA1.
+
+    Args:
+        data (bytes): the data to generate 64-bit integer hash from.
+
+    Returns:
+        int: an integer hash value that can be encoded using 64 bits.
+    """
+    return struct.unpack("<Q", hashlib.sha1(data.encode("utf-8")).digest()[:8])[0]
+
+
+def xxhash32(data: str):
+    return xxhash.xxh32_intdigest(data)  # type: ignore
+
+
+def xxhash64(data: str):
+    return xxhash.xxh64_intdigest(data)  # type: ignore
+
+
+@dataclass
+class HashConfig:
+    precision: Literal[32, 64] = 64
+    hash_fc: Literal["sha1", "xxhash"] = "xxhash"
+
+    @property
+    def np_dtype(self):
+        return np.uint32 if self.precision == 32 else np.uint64
+
+    @property
+    def np_descr(self):
+        return np.dtype(self.np_dtype).descr[0][1]
+
+    @property
+    def struct_format(self):
+        return "I" if self.precision == 32 else "Q"
+
+    @property
+    def max(self):
+        return np.iinfo(self.np_dtype).max
+
+    @property
+    def min(self):
+        return np.iinfo(self.np_dtype).min
+
+
+def create_hash_func(config: HashConfig) -> Callable[[str], int]:
+    # TODO: Check requirements for xxhash
+    if config.hash_fc == "sha1":
+        return sha1_hash32 if config.precision == 32 else sha1_hash64
+    elif config.hash_fc == "xxhash":
+        guarded_import("Hash Config", "xxhash")
+        return xxhash32 if config.precision == 32 else xxhash64
+    else:
+        raise ValueError(f"Unknown {config.hash_fc=}")
+
+
+DEFAULT_HASH_CONFIG = HashConfig()

--- a/src/datatrove/utils/hashing.py
+++ b/src/datatrove/utils/hashing.py
@@ -67,6 +67,9 @@ class HashConfig:
     def min(self):
         return np.iinfo(self.np_dtype).min
 
+    def __str__(self):
+        return f"{self.hash_fc}_{self.precision}b"
+
 
 def create_hash_func(config: HashConfig) -> Callable[[str], int]:
     # TODO: Check requirements for xxhash

--- a/src/datatrove/utils/hashing.py
+++ b/src/datatrove/utils/hashing.py
@@ -1,36 +1,11 @@
 # https://github.com/ekzhu/datasketch/blob/master/datasketch/hashfunc.py
-import hashlib
-import struct
 from dataclasses import dataclass
 from typing import Callable, Literal
 
 import numpy as np
 
 from datatrove.utils._import_utils import check_required_dependencies
-
-
-def sha1_hash32(data: str):
-    """A 32-bit hash function based on SHA1.
-
-    Args:
-        data (bytes): the data to generate 32-bit integer hash from.
-
-    Returns:
-        int: an integer hash value that can be encoded using 32 bits.
-    """
-    return struct.unpack("<I", hashlib.sha1(data.encode("utf-8")).digest()[:4])[0]
-
-
-def sha1_hash64(data: str):
-    """A 64-bit hash function based on SHA1.
-
-    Args:
-        data (bytes): the data to generate 64-bit integer hash from.
-
-    Returns:
-        int: an integer hash value that can be encoded using 64 bits.
-    """
-    return struct.unpack("<Q", hashlib.sha1(data.encode("utf-8")).digest()[:8])[0]
+from datatrove.utils.hashes.sha1 import sha1_hash32, sha1_hash64
 
 
 @dataclass

--- a/src/datatrove/utils/hashing.py
+++ b/src/datatrove/utils/hashing.py
@@ -8,10 +8,14 @@ from datatrove.utils._import_utils import check_required_dependencies
 from datatrove.utils.hashes.sha1 import sha1_hash32, sha1_hash64
 
 
-@dataclass
+@dataclass(frozen=True)
 class HashConfig:
     precision: Literal[32, 64] = 64
     hash_fc: Literal["sha1", "xxhash"] = "xxhash"
+
+    def __post_init__(self):
+        if self.hash_fc == "xxhash":
+            check_required_dependencies("xxhash Hashing", ["xxhash"])
 
     @property
     def np_dtype(self):
@@ -41,7 +45,6 @@ def create_hash_func(config: HashConfig) -> Callable[[str], int]:
     if config.hash_fc == "sha1":
         return sha1_hash32 if config.precision == 32 else sha1_hash64
     elif config.hash_fc == "xxhash":
-        check_required_dependencies("Hashing", ["xxhash"])
         from datatrove.utils.hashes.xxhash import xxhash32, xxhash64
 
         return xxhash32 if config.precision == 32 else xxhash64

--- a/src/datatrove/utils/text.py
+++ b/src/datatrove/utils/text.py
@@ -1,10 +1,6 @@
-import hashlib
 import re
-import struct
 import unicodedata
 from dataclasses import dataclass
-
-import xxhash
 
 
 PUNCTUATION = "!/—”:％１〈&(、━\\【#%「」，】；+^]~“《„';’{|∶´[=-`*．（–？！：$～«〉,><》)?）。…@_.\"}►»" + "".join(
@@ -68,39 +64,6 @@ def simplify_text(text: str, config=DEF_TEXT_NORM_CONFIG) -> str:
     if config.norm_monthnames:
         text = MONTHS_PATTERN.sub("MONTH", text)
     return text.strip()
-
-
-# https://github.com/ekzhu/datasketch/blob/master/datasketch/hashfunc.py
-def sha1_hash32(data):
-    """A 32-bit hash function based on SHA1.
-
-    Args:
-        data (bytes): the data to generate 32-bit integer hash from.
-
-    Returns:
-        int: an integer hash value that can be encoded using 32 bits.
-    """
-    return struct.unpack("<I", hashlib.sha1(data).digest()[:4])[0]
-
-
-def sha1_hash64(data):
-    """A 64-bit hash function based on SHA1.
-
-    Args:
-        data (bytes): the data to generate 64-bit integer hash from.
-
-    Returns:
-        int: an integer hash value that can be encoded using 64 bits.
-    """
-    return struct.unpack("<Q", hashlib.sha1(data).digest()[:8])[0]
-
-
-def xxhash32(data):
-    return xxhash.xxh32_intdigest(data)
-
-
-def xxhash64(data: str):
-    return xxhash.xxh64_intdigest(data)
 
 
 SPLIT_TEXT_DOCUMENTS = "DOCUMENT"

--- a/tests/pipeline/test_bloom_filter.py
+++ b/tests/pipeline/test_bloom_filter.py
@@ -4,6 +4,7 @@ import unittest
 
 from datatrove.data import Document
 from datatrove.pipeline.dedup.bloom_filter import SingleBloomFilter
+from tests.utils import use_hash_configs
 
 
 TEXT_0 = (
@@ -84,14 +85,17 @@ DOCS = [
 TARGETS = [True] * 8 + [False] * 3
 
 
-class SentenceDedup(unittest.TestCase):
+class BloomFilter(unittest.TestCase):
     def setUp(self):
         # Create a temporary directory
         self.tmp_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tmp_dir)
 
-    def test_sd(self):
-        bloom_filter = SingleBloomFilter(output_folder=self.tmp_dir, m_bytes=2**10 - 1, k=7, expected_elements=866)
+    @use_hash_configs(precision=[32])
+    def test_sd(self, hash_config):
+        bloom_filter = SingleBloomFilter(
+            output_folder=self.tmp_dir, m_bytes=2**10 - 1, k=7, expected_elements=866, hash_config=hash_config
+        )
 
         for doc_idx, doc in enumerate(DOCS):
             is_unique = bloom_filter.step(doc)

--- a/tests/pipeline/test_bloom_filter.py
+++ b/tests/pipeline/test_bloom_filter.py
@@ -3,7 +3,7 @@ import tempfile
 import unittest
 
 from datatrove.data import Document
-from datatrove.pipeline.dedup.bloom_filter import SingleBloomFilter
+from datatrove.pipeline.dedup.bloom_filter import BloomFilterConfig, SingleBloomFilter
 from tests.utils import use_hash_configs
 
 
@@ -94,7 +94,8 @@ class BloomFilter(unittest.TestCase):
     @use_hash_configs(precision=[32])
     def test_sd(self, hash_config):
         bloom_filter = SingleBloomFilter(
-            output_folder=self.tmp_dir, m_bytes=2**10 - 1, k=7, expected_elements=866, hash_config=hash_config
+            output_folder=self.tmp_dir,
+            config=BloomFilterConfig(m_bytes=2**10 - 1, k=7, expected_elements=866, hash_config=hash_config),
         )
 
         for doc_idx, doc in enumerate(DOCS):

--- a/tests/pipeline/test_minhash.py
+++ b/tests/pipeline/test_minhash.py
@@ -5,7 +5,6 @@ import struct
 import tempfile
 import unittest
 from collections import defaultdict, deque
-from dataclasses import replace
 from math import floor
 
 import numpy as np
@@ -20,9 +19,8 @@ from datatrove.pipeline.dedup.minhash import (
     MinhashDedupSignature,
     read_sigs,
 )
-from datatrove.utils.hashing import DEFAULT_HASH_CONFIG
 
-from ..utils import require_nltk, require_xxhash
+from ..utils import require_nltk, require_xxhash, use_hash_configs
 
 
 lorem_ipsum = """Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam euismod vel ante vitae rhoncus. Curabitur eu lectus et magna maximus facilisis eu non magna. Maecenas sed velit vitae est ornare placerat. Vestibulum quis consectetur nunc, a feugiat lorem. Cras in ipsum fringilla, vestibulum urna sit amet, viverra tortor. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Morbi euismod vestibulum elit id placerat. Fusce malesuada ultricies condimentum. Cras tincidunt eget lorem nec hendrerit. Aenean mattis arcu dolor, id semper velit ullamcorper malesuada. Aliquam non ipsum et eros venenatis aliquet. Proin eleifend interdum scelerisque. Interdum et malesuada fames ac ante ipsum primis in faucibus. Mauris nunc sapien, molestie eget convallis at, maximus nec ipsum. Morbi quam diam, blandit ut mollis at, varius eu tellus. Maecenas sem justo, porttitor at odio nec, interdum posuere ex.
@@ -44,215 +42,208 @@ class TestMinhash(unittest.TestCase):
         self.tmp_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tmp_dir)
 
-    def test_signatures(self):
-        for precision in (32, 64):
-            config = MinhashConfig(hash_config=replace(DEFAULT_HASH_CONFIG, precision=precision))
-            minhash = MinhashDedupSignature(output_folder=os.path.join(self.tmp_dir, "signatures1"), config=config)
-            shingles = minhash.get_shingles(lorem_ipsum)
-            sig = minhash.get_signature(shingles)
-            minhash2 = MinhashDedupSignature(output_folder=os.path.join(self.tmp_dir, "signatures2"), config=config)
-            # check consistency
-            assert sig == minhash2.get_signature(shingles)
+    @use_hash_configs()
+    def test_signatures(self, hash_config):
+        config = MinhashConfig(hash_config=hash_config)
+        minhash = MinhashDedupSignature(output_folder=os.path.join(self.tmp_dir, "signatures1"), config=config)
+        shingles = minhash.get_shingles(lorem_ipsum)
+        sig = minhash.get_signature(shingles)
+        minhash2 = MinhashDedupSignature(output_folder=os.path.join(self.tmp_dir, "signatures2"), config=config)
+        # check consistency
+        assert sig == minhash2.get_signature(shingles)
 
-            # check correct number of outputs
-            assert len(sig) == minhash.config.num_buckets
-            assert all((len(x) == minhash.config.hashes_per_bucket for x in sig))
+        # check correct number of outputs
+        assert len(sig) == minhash.config.num_buckets
+        assert all((len(x) == minhash.config.hashes_per_bucket for x in sig))
 
-            # check similarity approximation
-            for pctd in range(0, 100, 5):
-                dec = pctd / 100
-                endp = floor(len(lorem_ipsum) * dec)
-                textd = lorem_ipsum[:endp] + lorem_ipsum[len(lorem_ipsum) - 1 : endp : -1]
-                sigd = minhash.get_signature(minhash.get_shingles(textd))
-                simil = (
-                    sum([1 if a == b else 0 for ba, bb in zip(sig, sigd) for a, b in zip(ba, bb)]) / minhash.num_hashes
-                )
-                assert dec - 0.21 < simil < dec + 0.21
+        # check similarity approximation
+        for pctd in range(0, 100, 5):
+            dec = pctd / 100
+            endp = floor(len(lorem_ipsum) * dec)
+            textd = lorem_ipsum[:endp] + lorem_ipsum[len(lorem_ipsum) - 1 : endp : -1]
+            sigd = minhash.get_signature(minhash.get_shingles(textd))
+            simil = sum([1 if a == b else 0 for ba, bb in zip(sig, sigd) for a, b in zip(ba, bb)]) / minhash.num_hashes
+            assert dec - 0.21 < simil < dec + 0.21
 
-            # check output file format and order
-            samples = [Document(f"sample {i}, {lorem_ipsum[i:: 10]}", id="test") for i in range(100)]
-            minhash(samples)
-            for bi in range(config.num_buckets):
-                with minhash.output_folder.open(f"bucket_{bi:03d}/00000.minhash.sig", "rb") as f:
-                    prev = None
-                    doc_ids = set()
-                    S = np.dtype(config.hash_config.np_dtype).itemsize
-                    for di in range(100):
-                        data = struct.unpack(
-                            f"<%s{config.hash_config.struct_format}" % config.hashes_per_bucket,
-                            f.read(config.hashes_per_bucket * S),
-                        )
-                        doc_id = struct.unpack("<I", f.read(struct.calcsize("I")))[0]
-                        # ensure sorted order
-                        assert prev is None or data >= prev
-                        prev = data
-                        assert 0 <= doc_id < 100
-                        doc_ids.add(doc_id)
-                    assert len(doc_ids) == 100
-
-    def test_buckets_and_cluster(self):
-        for precision in (32, 64):
-            sigs_folder = os.path.join(self.tmp_dir, "b_signatures")
-            buckets_folder = os.path.join(self.tmp_dir, "b_buckets")
-            clusters_folder = os.path.join(self.tmp_dir, "b_clusters")
-            config = MinhashConfig(hash_config=replace(DEFAULT_HASH_CONFIG, precision=precision))
-
-            signatures_block = MinhashDedupSignature(output_folder=sigs_folder, config=config)
-            buckets_block = MinhashDedupBuckets(
-                input_folder=sigs_folder,
-                output_folder=buckets_folder,
-                config=config,
-            )
-
-            clusters = [[0, 20, 50], [400, 420], [800, 810, 820, 840, 860], [1205, 1215, 1225, 1245], [1600], [2000]]
-
-            cluster_samples = [
-                Document(text=lorem_ipsum[x : x + 300], id=f"{ci}_{xi}", metadata={"ci": ci, "xi": xi})
-                for ci, cluster in enumerate(clusters)
-                for xi, x in enumerate(cluster)
-            ]
-
-            signatures_block(cluster_samples)
-            # test file read
-            for fi, file in enumerate(buckets_block.input_folder.list_files()):
-                last = None
-                for sig in read_sigs(buckets_block.input_folder.open(file, "rb"), fi, config):
-                    assert 0 <= sig.doc_id < 100
-                    assert last is None or sig.sig >= last
-                    assert len(sig.sig) == config.hashes_per_bucket
-                    last = sig.sig
-
-            # test duplicate pairs
-            for b in range(config.num_buckets * 10):
-                buckets_block(None, rank=b, world_size=config.num_buckets * 10)
-            bucket_results_folder = get_datafolder(buckets_folder)
-            dup_files = bucket_results_folder.list_files(glob_pattern="*.dups")
-            pairs = defaultdict(set)
-            for dup_file in dup_files:
-                with bucket_results_folder.open(dup_file, "rb") as df:
-                    while data := df.read(4 * struct.calcsize("I")):
-                        f1, d1, f2, d2 = struct.unpack("<4I", data)
-                        assert f1 == f2 == 0
-                        assert cluster_samples[d1].metadata["ci"] == cluster_samples[d2].metadata["ci"]
-                        pairs[d1].add(d2)
-                        pairs[d2].add(d1)
-            doc_id = 0
-            for cluster in clusters:
-                print(cluster)
-                print(pairs)
-                for a in range(doc_id, doc_id + len(cluster)):
-                    assert len(cluster) < 2 or any(
-                        a in pairs[b] for b in range(doc_id, doc_id + len(cluster)) if a != b
+        # check output file format and order
+        samples = [Document(f"sample {i}, {lorem_ipsum[i:: 10]}", id="test") for i in range(100)]
+        minhash(samples)
+        for bi in range(config.num_buckets):
+            with minhash.output_folder.open(f"bucket_{bi:03d}/00000.minhash.sig", "rb") as f:
+                prev = None
+                doc_ids = set()
+                S = np.dtype(config.hash_config.np_dtype).itemsize
+                for di in range(100):
+                    data = struct.unpack(
+                        f"<%s{config.hash_config.struct_format}" % config.hashes_per_bucket,
+                        f.read(config.hashes_per_bucket * S),
                     )
-                doc_id += len(cluster)
+                    doc_id = struct.unpack("<I", f.read(struct.calcsize("I")))[0]
+                    # ensure sorted order
+                    assert prev is None or data >= prev
+                    prev = data
+                    assert 0 <= doc_id < 100
+                    doc_ids.add(doc_id)
+                assert len(doc_ids) == 100
 
-            # clustering
-            cluster_block = MinhashDedupCluster(bucket_results_folder, clusters_folder, config=config)
-            cluster_block(None)
+    @use_hash_configs()
+    def test_buckets_and_cluster(self, hash_config):
+        sigs_folder = os.path.join(self.tmp_dir, "b_signatures")
+        buckets_folder = os.path.join(self.tmp_dir, "b_buckets")
+        clusters_folder = os.path.join(self.tmp_dir, "b_clusters")
+        config = MinhashConfig(hash_config=hash_config)
 
-            cluster_results_folder = get_datafolder(clusters_folder)
-            remove_ids = set()
-            with cluster_results_folder.open(cluster_results_folder.list_files()[0], "rb") as df:
-                while data := df.read(struct.calcsize("I")):
-                    remove_ids.add(struct.unpack("<I", data)[0])
-            doc_id = 0
-            kept = set()
-            for ci, cluster in enumerate(clusters):
-                to_remove = 0
-                for xi, a in enumerate(range(doc_id, doc_id + len(cluster))):
-                    if a in remove_ids:
-                        to_remove += 1
-                    else:
-                        kept.add(f"{ci}_{xi}")
-                doc_id += len(cluster)
-                assert to_remove == len(cluster) - 1
+        signatures_block = MinhashDedupSignature(output_folder=sigs_folder, config=config)
+        buckets_block = MinhashDedupBuckets(
+            input_folder=sigs_folder,
+            output_folder=buckets_folder,
+            config=config,
+        )
 
-            # filtering
-            filter_block = MinhashDedupFilter(cluster_results_folder)
-            filtered = filter_block(cluster_samples)
-            filtered_ids = {x.id for x in filtered}
-            assert filtered_ids == kept
+        clusters = [[0, 20, 50], [400, 420], [800, 810, 820, 840, 860], [1205, 1215, 1225, 1245], [1600], [2000]]
 
-    def test_multiprocess_s2(self):
-        for precision in (32, 64):
-            sigs_folder = os.path.join(self.tmp_dir, "b_signatures")
-            buckets_folder1 = os.path.join(self.tmp_dir, "b_buckets")
-            buckets_folder2 = os.path.join(self.tmp_dir, "b_buckets2")
-            config = MinhashConfig(hash_config=replace(DEFAULT_HASH_CONFIG, precision=precision))
+        cluster_samples = [
+            Document(text=lorem_ipsum[x : x + 400], id=f"{ci}_{xi}", metadata={"ci": ci, "xi": xi})
+            for ci, cluster in enumerate(clusters)
+            for xi, x in enumerate(cluster)
+        ]
 
-            signatures_block = MinhashDedupSignature(output_folder=sigs_folder, config=config)
-            buckets_block1 = MinhashDedupBuckets(
-                input_folder=sigs_folder,
-                output_folder=buckets_folder1,
-                config=config,
-            )
-            buckets_block2 = MinhashDedupBuckets(
-                input_folder=sigs_folder,
-                output_folder=buckets_folder2,
-                config=config,
-            )
+        signatures_block(cluster_samples)
+        # test file read
+        for fi, file in enumerate(buckets_block.input_folder.list_files()):
+            last = None
+            for sig in read_sigs(buckets_block.input_folder.open(file, "rb"), fi, config):
+                assert 0 <= sig.doc_id < 100
+                assert last is None or sig.sig >= last
+                assert len(sig.sig) == config.hashes_per_bucket
+                last = sig.sig
 
-            samples = [Document(text=lorem_ipsum[x : x + 200], id="?") for x in range(0, len(lorem_ipsum) - 200, 10)]
+        # test duplicate pairs
+        for b in range(config.num_buckets * 10):
+            buckets_block(None, rank=b, world_size=config.num_buckets * 10)
+        bucket_results_folder = get_datafolder(buckets_folder)
+        dup_files = bucket_results_folder.list_files(glob_pattern="*.dups")
+        pairs = defaultdict(set)
+        for dup_file in dup_files:
+            with bucket_results_folder.open(dup_file, "rb") as df:
+                while data := df.read(4 * struct.calcsize("I")):
+                    f1, d1, f2, d2 = struct.unpack("<4I", data)
+                    assert f1 == f2 == 0
+                    assert cluster_samples[d1].metadata["ci"] == cluster_samples[d2].metadata["ci"]
+                    pairs[d1].add(d2)
+                    pairs[d2].add(d1)
+        doc_id = 0
+        for cluster in clusters:
+            print(cluster)
+            print(pairs)
+            for a in range(doc_id, doc_id + len(cluster)):
+                assert len(cluster) < 2 or any(a in pairs[b] for b in range(doc_id, doc_id + len(cluster)) if a != b)
+            doc_id += len(cluster)
 
-            signatures_block(samples)
-            # test duplicate pairs
-            for b in range(config.num_buckets):
-                buckets_block1(None, rank=b, world_size=config.num_buckets)
-            for b in range(config.num_buckets * 10):
-                buckets_block2(None, rank=b, world_size=config.num_buckets * 10)
+        # clustering
+        cluster_block = MinhashDedupCluster(bucket_results_folder, clusters_folder, config=config)
+        cluster_block(None)
 
-            bucket_results_folder1 = get_datafolder(buckets_folder1)
-            bucket_results_folder2 = get_datafolder(buckets_folder2)
-            dup_files1 = bucket_results_folder1.list_files(glob_pattern="*.dups")
-            dup_files2 = bucket_results_folder2.list_files(glob_pattern="*.dups")
-            for bucket, dup_file1 in enumerate(dup_files1):
-                alllines = []
-                with bucket_results_folder1.open(dup_file1, mode="rb") as df1:
-                    while data := df1.read(4 * struct.calcsize("I")):
-                        alllines.append(struct.unpack("<4I", data))
-                pi = 0
-                for filei in range(bucket * 10, (bucket + 1) * 10):
-                    pidelta = 0
-                    with bucket_results_folder2.open(dup_files2[filei], mode="rb") as df2:
-                        while data := df2.read(4 * struct.calcsize("I")):
-                            assert alllines[pi + pidelta] == struct.unpack("<4I", data)
-                            pidelta += 1
-                    pi += pidelta
+        cluster_results_folder = get_datafolder(clusters_folder)
+        remove_ids = set()
+        with cluster_results_folder.open(cluster_results_folder.list_files()[0], "rb") as df:
+            while data := df.read(struct.calcsize("I")):
+                remove_ids.add(struct.unpack("<I", data)[0])
+        doc_id = 0
+        kept = set()
+        for ci, cluster in enumerate(clusters):
+            to_remove = 0
+            for xi, a in enumerate(range(doc_id, doc_id + len(cluster))):
+                if a in remove_ids:
+                    to_remove += 1
+                else:
+                    kept.add(f"{ci}_{xi}")
+            doc_id += len(cluster)
+            assert to_remove == len(cluster) - 1
 
-                assert pi == len(alllines)
+        # filtering
+        filter_block = MinhashDedupFilter(cluster_results_folder)
+        filtered = filter_block(cluster_samples)
+        filtered_ids = {x.id for x in filtered}
+        assert filtered_ids == kept
 
-                # check if actually read the same hashes, when using 1 worker or 10
-                for bucket in range(config.num_buckets):
-                    sigs_df = get_datafolder(sigs_folder)
-                    sig_files = sigs_df.list_files(subdirectory=f"bucket_{bucket:03d}")
+    @use_hash_configs()
+    def test_multiprocess_s2(self, hash_config):
+        sigs_folder = os.path.join(self.tmp_dir, "b_signatures")
+        buckets_folder1 = os.path.join(self.tmp_dir, "b_buckets")
+        buckets_folder2 = os.path.join(self.tmp_dir, "b_buckets2")
+        config = MinhashConfig(hash_config=hash_config)
+
+        signatures_block = MinhashDedupSignature(output_folder=sigs_folder, config=config)
+        buckets_block1 = MinhashDedupBuckets(
+            input_folder=sigs_folder,
+            output_folder=buckets_folder1,
+            config=config,
+        )
+        buckets_block2 = MinhashDedupBuckets(
+            input_folder=sigs_folder,
+            output_folder=buckets_folder2,
+            config=config,
+        )
+
+        samples = [Document(text=lorem_ipsum[x : x + 200], id="?") for x in range(0, len(lorem_ipsum) - 200, 10)]
+
+        signatures_block(samples)
+        # test duplicate pairs
+        for b in range(config.num_buckets):
+            buckets_block1(None, rank=b, world_size=config.num_buckets)
+        for b in range(config.num_buckets * 10):
+            buckets_block2(None, rank=b, world_size=config.num_buckets * 10)
+
+        bucket_results_folder1 = get_datafolder(buckets_folder1)
+        bucket_results_folder2 = get_datafolder(buckets_folder2)
+        dup_files1 = bucket_results_folder1.list_files(glob_pattern="*.dups")
+        dup_files2 = bucket_results_folder2.list_files(glob_pattern="*.dups")
+        for bucket, dup_file1 in enumerate(dup_files1):
+            alllines = []
+            with bucket_results_folder1.open(dup_file1, mode="rb") as df1:
+                while data := df1.read(4 * struct.calcsize("I")):
+                    alllines.append(struct.unpack("<4I", data))
+            pi = 0
+            for filei in range(bucket * 10, (bucket + 1) * 10):
+                pidelta = 0
+                with bucket_results_folder2.open(dup_files2[filei], mode="rb") as df2:
+                    while data := df2.read(4 * struct.calcsize("I")):
+                        assert alllines[pi + pidelta] == struct.unpack("<4I", data)
+                        pidelta += 1
+                pi += pidelta
+
+            assert pi == len(alllines)
+
+            # check if actually read the same hashes, when using 1 worker or 10
+            for bucket in range(config.num_buckets):
+                sigs_df = get_datafolder(sigs_folder)
+                sig_files = sigs_df.list_files(subdirectory=f"bucket_{bucket:03d}")
+                sig_readers = [
+                    read_sigs(sigs_df.open(file, mode="rb"), file_i, config) for file_i, file in enumerate(sig_files)
+                ]
+                pq = [x for x in [next(sig_reader, None) for sig_reader in sig_readers] if x is not None]
+                heapq.heapify(pq)
+                ordered = deque()
+                while pq:
+                    v = heapq.heappop(pq)
+                    ordered.append(v)
+                    next_sig = next(sig_readers[v.reader_id], None)
+                    if next_sig:
+                        heapq.heappush(pq, next_sig)
+                for bucket_worker in range(10):
+                    hash_min, hash_max = buckets_block2.get_worker_hash_range(
+                        sig_files, bucket * 10 + bucket_worker, config.num_buckets * 10
+                    )
                     sig_readers = [
-                        read_sigs(sigs_df.open(file, mode="rb"), file_i, config)
+                        read_sigs(sigs_df.open(file, mode="rb"), file_i, config, min_hash=hash_min, max_hash=hash_max)
                         for file_i, file in enumerate(sig_files)
                     ]
                     pq = [x for x in [next(sig_reader, None) for sig_reader in sig_readers] if x is not None]
-                    heapq.heapify(pq)
-                    ordered = deque()
                     while pq:
                         v = heapq.heappop(pq)
-                        ordered.append(v)
+                        nextv = ordered.popleft()
+                        assert v == nextv
                         next_sig = next(sig_readers[v.reader_id], None)
                         if next_sig:
                             heapq.heappush(pq, next_sig)
-                    for bucket_worker in range(10):
-                        hash_min, hash_max = buckets_block2.get_worker_hash_range(
-                            sig_files, bucket * 10 + bucket_worker, config.num_buckets * 10
-                        )
-                        sig_readers = [
-                            read_sigs(
-                                sigs_df.open(file, mode="rb"), file_i, config, min_hash=hash_min, max_hash=hash_max
-                            )
-                            for file_i, file in enumerate(sig_files)
-                        ]
-                        pq = [x for x in [next(sig_reader, None) for sig_reader in sig_readers] if x is not None]
-                        while pq:
-                            v = heapq.heappop(pq)
-                            nextv = ordered.popleft()
-                            assert v == nextv
-                            next_sig = next(sig_readers[v.reader_id], None)
-                            if next_sig:
-                                heapq.heappush(pq, next_sig)

--- a/tests/pipeline/test_ngrams_decont.py
+++ b/tests/pipeline/test_ngrams_decont.py
@@ -5,7 +5,7 @@ import unittest
 
 from datatrove.data import Document
 from datatrove.pipeline.decont import NGramsDecontConfig, NGramsDecontFilter, NGramsDecontIndexer
-from tests.utils import require_xxhash
+from tests.utils import require_xxhash, use_hash_configs
 
 
 TEXTS = [
@@ -42,9 +42,12 @@ class TestNGramDecont(unittest.TestCase):
         nfilter = NGramsDecontFilter(self.tmp_dir, config=config)
         return tuple([int(doc.id) for doc in nfilter(copy.deepcopy(DOCS))])
 
-    def test_label_only(self):
+    @use_hash_configs()
+    def test_label_only(self, hash_config):
         self.assertEqual(
-            self.get_test_results(NGramsDecontConfig(find_query_ngrams=False, find_overlap_ngrams=False)),
+            self.get_test_results(
+                NGramsDecontConfig(find_query_ngrams=False, find_overlap_ngrams=False, hash_config=hash_config)
+            ),
             (0, 2, 3, 4, 5, 6),
         )
 

--- a/tests/pipeline/test_sentence_deduplication.py
+++ b/tests/pipeline/test_sentence_deduplication.py
@@ -13,7 +13,7 @@ from datatrove.pipeline.dedup.sentence_dedup import (
     SentenceFindDedups,
 )
 
-from ..utils import require_nltk
+from ..utils import require_nltk, use_hash_configs
 
 
 def get_random_string(n: int = 20):
@@ -140,14 +140,15 @@ class SentenceDedup(unittest.TestCase):
     def setUp(self):
         # Create a temporary directory
         self.tmp_dir = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, self.tmp_dir)
+        self.addCleanup(shutil.rmtree, self.tmp_dir, ignore_errors=True)
 
     def test_sd(self):
-        signature_creation = SentenceDedupSignature(output_folder=self.tmp_dir + "/sigs")
-        find_duplicates = SentenceFindDedups(data_folder=self.tmp_dir + "/sigs", output_folder=self.tmp_dir + "/dups")
-        dedup_filter = SentenceDedupFilter(
-            data_folder=self.tmp_dir + "/dups", config=SentDedupConfig(min_doc_words=0, min_num_sentences=0)
+        config = SentDedupConfig(min_doc_words=0, min_num_sentences=0)
+        signature_creation = SentenceDedupSignature(output_folder=self.tmp_dir + "/sigs", config=config)
+        find_duplicates = SentenceFindDedups(
+            data_folder=self.tmp_dir + "/sigs", output_folder=self.tmp_dir + "/dups", config=config
         )
+        dedup_filter = SentenceDedupFilter(data_folder=self.tmp_dir + "/dups", config=config)
 
         signature_creation(data=DOCS)
         find_duplicates()
@@ -155,12 +156,13 @@ class SentenceDedup(unittest.TestCase):
             self.assertEqual(doc.text, TARGETS[i])
 
     def test_sd_worker(self):
-        signature_creation = SentenceDedupSignature(output_folder=self.tmp_dir + "/sigs")
+        config = SentDedupConfig(min_doc_words=0, min_num_sentences=0)
+        signature_creation = SentenceDedupSignature(output_folder=self.tmp_dir + "/sigs", config=config)
 
-        find_duplicates = SentenceFindDedups(data_folder=self.tmp_dir + "/sigs", output_folder=self.tmp_dir + "/dups")
-        dedup_filter = SentenceDedupFilter(
-            data_folder=self.tmp_dir + "/dups", config=SentDedupConfig(min_doc_words=0, min_num_sentences=0)
+        find_duplicates = SentenceFindDedups(
+            data_folder=self.tmp_dir + "/sigs", output_folder=self.tmp_dir + "/dups", config=config
         )
+        dedup_filter = SentenceDedupFilter(data_folder=self.tmp_dir + "/dups", config=config)
 
         signature_creation(data=DOCS, rank=0, world_size=2)
         signature_creation(data=DOCS_2, rank=1, world_size=2)
@@ -172,13 +174,17 @@ class SentenceDedup(unittest.TestCase):
         for i, doc in enumerate(dedup_filter(data=copy.deepcopy(DOCS_2), rank=1, world_size=2)):
             self.assertEqual(doc.text, TARGETS_WS2_1[i])
 
-    def test_distributed_find_dups(self):
-        signature_creation = SentenceDedupSignature(output_folder=self.tmp_dir + "/sigs", finder_workers=50)
-
-        find_duplicates = SentenceFindDedups(data_folder=self.tmp_dir + "/sigs", output_folder=self.tmp_dir + "/dups")
-        dedup_filter = SentenceDedupFilter(
-            data_folder=self.tmp_dir + "/dups", config=SentDedupConfig(min_doc_words=0, min_num_sentences=0)
+    @use_hash_configs()
+    def test_distributed_find_dups(self, hash_config):
+        config = SentDedupConfig(hash_config=hash_config, min_doc_words=0, min_num_sentences=0)
+        signature_creation = SentenceDedupSignature(
+            output_folder=self.tmp_dir + "/sigs", finder_workers=50, config=config
         )
+
+        find_duplicates = SentenceFindDedups(
+            data_folder=self.tmp_dir + "/sigs", output_folder=self.tmp_dir + "/dups", config=config
+        )
+        dedup_filter = SentenceDedupFilter(data_folder=self.tmp_dir + "/dups", config=config)
 
         signature_creation(data=DOCS, rank=0, world_size=2)
         signature_creation(data=DOCS_2, rank=1, world_size=2)

--- a/tests/pipeline/test_sentence_deduplication.py
+++ b/tests/pipeline/test_sentence_deduplication.py
@@ -13,7 +13,7 @@ from datatrove.pipeline.dedup.sentence_dedup import (
     SentenceFindDedups,
 )
 
-from ..utils import require_nltk, use_hash_configs
+from ..utils import require_nltk, require_xxhash, use_hash_configs
 
 
 def get_random_string(n: int = 20):
@@ -136,6 +136,7 @@ TARGETS_WS2_1 = [
 
 
 @require_nltk
+@require_xxhash
 class SentenceDedup(unittest.TestCase):
     def setUp(self):
         # Create a temporary directory

--- a/tests/pipeline/test_url_deduplication.py
+++ b/tests/pipeline/test_url_deduplication.py
@@ -10,7 +10,7 @@ from datatrove.pipeline.dedup.url_dedup import (
     UrlDedupSignature,
     UrlFindDedups,
 )
-from tests.utils import require_xxhash
+from tests.utils import require_xxhash, use_hash_configs
 
 
 DOCS = [
@@ -134,8 +134,9 @@ class UrlDedup(unittest.TestCase):
             {doc.metadata["url"] for doc in DOCS},
         )
 
-    def test_distributed_find_dups(self):
-        config = UrlDedupConfig(document_priority=lambda x: int(x.id))
+    @use_hash_configs()
+    def test_distributed_find_dups(self, hash_config):
+        config = UrlDedupConfig(document_priority=lambda x: int(x.id), hash_config=hash_config)
 
         signature_creation = UrlDedupSignature(output_folder=self.tmp_dir + "/sigs", finder_workers=50, config=config)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,34 @@
+import itertools
 import unittest
+from functools import wraps
+from typing import get_args, get_type_hints
+
+from datatrove.utils.hashing import HashConfig
+
+
+def use_hash_configs(
+    precision: list[int] = list(get_args(get_type_hints(HashConfig)["precision"])), hash_fc: list[str] = ["xxhash"]
+):
+    """
+    Decorator which runs the wrapped test function, with hash config of all combinations of given precision and hash_fc
+    Args:
+        precision (list[int]): List of precision values to use. Defaults to all possible values.
+        hash_fc (list[str]): List of hash functions to use. Defaults to ["xxhash"].
+    """
+
+    def wrapper(f):
+        @wraps(f)
+        def inner_wraper(self: unittest.TestCase, *args, **kwargs):
+            for p, h in itertools.product(precision, hash_fc):
+                config = HashConfig(precision=p, hash_fc=h)
+                self.setUp()
+                f(self, *args, config, **kwargs)
+                self.tearDown()
+                self.doCleanups()
+
+        return inner_wraper
+
+    return wrapper
 
 
 def require_nltk(test_case):


### PR DESCRIPTION
- Introduces new class `HashConfig`, used for specifying how what hashfc/precission to use
- Migrates all classes to the new config for consistency
- Fixing bug in `SentenceDedup`. The bug occurs when hashes from first stage don't cover the whole hash space. This results in non-correspondance between file_name and it's order (id) in signatures folder. However in second order we rely on this correspondance as we assume `id.sig == file_name`. I fixed this by relying solely on the file_name. The same bug occurs in `url_dedup`. Lastly I made the same change to `minhash`, where this bug shouldn't occur, but it makes more sense to not assume this correspondance.
- Separated hashing code to new files
- To make `xxhash` optional, we no longer can use `requires....` on class blocks as it's possible to also use `sha1` there. The check for dependency is thus done when the new hash function is created. See: `create_hash_func`
- Added a decorator for testing the hash configs. By default it only runs with 32/64b precission and don't alter the hash function, the reasoning is to save a bit of time as we don't assume that the hash_fc change should break anything.