### PR TITLE
Fix snapshot representation and numeric conversion in example Code (fineweb)

### DIFF
--- a/examples/fineweb.py
+++ b/examples/fineweb.py
@@ -24,7 +24,7 @@ from datatrove.pipeline.writers.jsonl import JsonlWriter
 """
     we first ran the following pipeline for each dump
 """
-DUMP_TO_PROCESS = "CC-MAIN-2O23-5O"  # example
+DUMP_TO_PROCESS = "CC-MAIN-2023-50"  # example
 
 MAIN_OUTPUT_PATH = "s3://some_s3_bucket"
 FILTERING_OUTPUT_PATH = f"{MAIN_OUTPUT_PATH}/base_processing"


### PR DESCRIPTION
While attempting to run the fineweb example code, I encountered an issue there is no specified directory with s3 due to a misunderstanding of the year '2O24', where 'O' was mistakenly used instead of '0'. This led me to believe there was a problem related to the S3 module managed by fsspec, prompting extensive checks for potential module issues.

Upon closer inspection, I realized that the year was incorrectly expressed using an alphabetic character instead of numeric. To prevent future confusion and ensure clarity, I have corrected the year from '2O24' to '2024' and made sure all alphabetic representations that should be numeric are appropriately converted.

This PR aims to rectify these discrepancies to avoid similar misunderstandings and improve the readability and accuracy of examples.