### PR TITLE
Extend randomize_start feature to local executor

### DIFF
--- a/src/datatrove/executor/base.py
+++ b/src/datatrove/executor/base.py
@@ -1,5 +1,7 @@
 import dataclasses
 import json
+import random
+import time
 from abc import ABC, abstractmethod
 from collections import deque
 from collections.abc import Sequence
@@ -35,10 +37,12 @@ class PipelineExecutor(ABC):
         pipeline: list[PipelineStep | Callable],
         logging_dir: DataFolderLike = None,
         skip_completed: bool = True,
+        randomize_start: bool = False,
     ):
         self.pipeline: list[PipelineStep | Callable] = pipeline
         self.logging_dir = get_datafolder(logging_dir if logging_dir else f"logs/{get_timestamp()}_{get_random_str()}")
         self.skip_completed = skip_completed
+        self.randomize_start = randomize_start
 
     @abstractmethod
     def run(self):
@@ -74,6 +78,9 @@ class PipelineExecutor(ABC):
             return PipelineStats()
         logfile = add_task_logger(self.logging_dir, rank, local_rank)
         log_pipeline(self.pipeline)
+
+        if self.randomize_start:
+            time.sleep(random.randint(0, 60 * 3))
         try:
             # pipe data from one step to the next
             pipelined_data = None

--- a/src/datatrove/executor/local.py
+++ b/src/datatrove/executor/local.py
@@ -1,4 +1,3 @@
-import random
 import time
 from copy import deepcopy
 from functools import partial
@@ -47,14 +46,13 @@ class LocalPipelineExecutor(PipelineExecutor):
         local_rank_offset: int = 0,
         randomize_start: bool = False,
     ):
-        super().__init__(pipeline, logging_dir, skip_completed)
+        super().__init__(pipeline, logging_dir, skip_completed, randomize_start)
         self.tasks = tasks
         self.workers = workers if workers != -1 else tasks
         self.start_method = start_method
         self.local_tasks = local_tasks if local_tasks != -1 else tasks
         self.local_rank_offset = local_rank_offset
         self.depends = depends
-        self.randomize_start = randomize_start
         if self.local_rank_offset + self.local_tasks > self.tasks:
             raise ValueError(
                 f"Local tasks go beyond the total tasks (local_rank_offset + local_tasks = {self.local_rank_offset + self.local_tasks} > {self.tasks} = tasks)"
@@ -75,8 +73,6 @@ class LocalPipelineExecutor(PipelineExecutor):
         """
         local_rank = ranks_q.get()
         try:
-            if self.randomize_start:
-                time.sleep(random.randint(0, 60 * 3))
             return self._run_for_rank(rank, local_rank)
         finally:
             if completed and completed_lock:

--- a/src/datatrove/executor/slurm.py
+++ b/src/datatrove/executor/slurm.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import math
 import os
-import random
 import signal
 import subprocess
 import sys
@@ -114,7 +113,7 @@ class SlurmPipelineExecutor(PipelineExecutor):
         srun_args: dict = None,
         tasks_per_job: int = 1,
     ):
-        super().__init__(pipeline, logging_dir, skip_completed)
+        super().__init__(pipeline, logging_dir, skip_completed, randomize_start)
         self.tasks = tasks
         self.workers = workers
         self.partition = partition
@@ -178,8 +177,6 @@ class SlurmPipelineExecutor(PipelineExecutor):
                     break
                 rank = all_ranks[rank_to_run]
 
-                if self.randomize_start:
-                    time.sleep(random.randint(0, 60 * 3))
                 self._run_for_rank(rank)
         else:
             # we still have to launch the job


### PR DESCRIPTION
Extend the randomize_start option, which is available in the slurm executor, to the local executor. Initially, it may seem that randomize_start is unnecessary for local operations. However, specific scenarios, such as processing WARCs directly from Common Crawl's S3, highlight its importance. When dealing with S3, there is a risk of exceeding the permitted rate limit for API calls resulting in potential blocking, if to much API calls are occured simultaneously. By enabling either sequential or randomized execution through the executor, we can mitigate this issue.

The addition of this feature to the local executor was prompted by running the fineweb examples locally. 