### PR TITLE
Issues w/ DatatroveFolderDataset

### DIFF
--- a/src/datatrove/utils/dataset.py
+++ b/src/datatrove/utils/dataset.py
@@ -1,7 +1,4 @@
-import re
 from bisect import bisect
-from re import Pattern
-from typing import Union
 
 import numpy as np
 import torch
@@ -83,7 +80,7 @@ if is_torch_available():
             self,
             folder_path: str,
             seq_len: int,
-            filename_pattern: Union[Pattern, str] = None,
+            filename_pattern: str = None,
             recursive: bool = True,
             token_size: int = 2,
             max_tokens: int | None = None,
@@ -91,14 +88,12 @@ if is_torch_available():
             seed: int = 42,
         ):
             self.folder_path = folder_path
-            if isinstance(filename_pattern, str):
-                filename_pattern = re.compile(filename_pattern)
             self.filename_pattern = filename_pattern
             fs, folder_path = url_to_fs(folder_path)
             matched_files = (
                 fs.find(folder_path, detail=False, maxdepth=1 if not recursive else None)
                 if not filename_pattern
-                else fs.glob(filename_pattern.pattern, maxdepth=1 if not recursive else None)
+                else fs.glob(filename_pattern, maxdepth=1 if not recursive else None)
             )
             if not matched_files:
                 raise FileNotFoundError(f'No files matching "{filename_pattern}" found in {folder_path}')

--- a/src/datatrove/utils/dataset.py
+++ b/src/datatrove/utils/dataset.py
@@ -98,7 +98,7 @@ if is_torch_available():
             matched_files = (
                 fs.find(folder_path, detail=False, maxdepth=1 if not recursive else None)
                 if not filename_pattern
-                else fs.glob(filename_pattern, maxdepth=1 if not recursive else None)
+                else fs.glob(filename_pattern.pattern, maxdepth=1 if not recursive else None)
             )
             if not matched_files:
                 raise FileNotFoundError(f'No files matching "{filename_pattern}" found in {folder_path}')

--- a/src/datatrove/utils/dataset.py
+++ b/src/datatrove/utils/dataset.py
@@ -42,12 +42,10 @@ if is_torch_available():
             self._f = None
 
         def __getitem__(self, item):
-            # We loop on the dataset if asking for an index larger than the dataset size
-            epoch_item = item % len(self)
             if not self._f:
                 self._f = self.fs.open(self.file_path, "rb")
             chunk_size = self.token_size * (self.seq_len + 1)
-            self._f.seek(epoch_item * chunk_size)
+            self._f.seek(item * chunk_size)
             return {
                 "input_ids": torch.as_tensor(
                     np.frombuffer(self._f.read(chunk_size), np.uint16 if self.token_size == 2 else np.uint32).astype(
@@ -123,13 +121,12 @@ if is_torch_available():
             self.current_file = 0
 
         def __getitem__(self, item):
-            epoch_item = item % len(self)
             # check if we are in the same file as before
-            if not (self.lens[self.current_file] <= epoch_item < self.lens[self.current_file + 1]):
+            if not (self.lens[self.current_file] <= item < self.lens[self.current_file + 1]):
                 # figure out current file
-                self.current_file = bisect(self.lens, epoch_item) - 1
+                self.current_file = bisect(self.lens, item) - 1
             # subtract file starting offset
-            return self.files[self.current_file][epoch_item - self.lens[self.current_file]]
+            return self.files[self.current_file][item - self.lens[self.current_file]]
 
         def __len__(self):
             return self.lens[-1] if self.lens else 0

--- a/src/datatrove/utils/dataset.py
+++ b/src/datatrove/utils/dataset.py
@@ -58,6 +58,10 @@ if is_torch_available():
         def __len__(self):
             return self._len
 
+        def __del__(self):
+            if self._f:
+                self._f.close()
+
     class DatatroveFolderDataset(Dataset):
         """
         Dataset for a folder of .ds files


### PR DESCRIPTION
Hi!

While using `DatatroveFolderDataset` I encountered the following:
1. While using a `LocalFileSystem`, a folder containing tokenised documents and using a `filename_pattern` the call to [`fs.glob(...)`](https://github.com/huggingface/datatrove/blob/0f2c69f8249aa0c53ebcf10afa2394da506a953f/src/datatrove/utils/dataset.py#L101) fails because it's expecting a object with [`.endswith()`](https://filesystem-spec.readthedocs.io/en/latest/_modules/fsspec/spec.html#AbstractFileSystem.glob) method not a `Pattern`. Here is an example:

```python
import re
from fsspec.core import url_to_fs

fs, folder_path = url_to_fs("src/datatrove")

pattern = "src/datatrove/*.py"
filename_pattern = re.compile(pattern)

fs.glob(filename_pattern, maxdepth=1)

AttributeError                            Traceback (most recent call last)
Cell In[31], [line 1](vscode-notebook-cell:?execution_count=31&line=1)
----> [1](vscode-notebook-cell:?execution_count=31&line=1) fs.glob(filename_pattern, maxdepth=1)

File ~/.local/lib/python3.10/site-packages/fsspec/spec.py:564, in AbstractFileSystem.glob(self, path, maxdepth, **kwargs)
     import re
     seps = (os.path.sep, os.path.altsep) if os.path.altsep else (os.path.sep,)
     ends_with_sep = path.endswith(seps)  # _strip_protocol strips trailing slash
     path = self._strip_protocol(path)
     append_slash_to_dirname = ends_with_sep or path.endswith(tuple(sep + "**" for sep in seps))

AttributeError: 're.Pattern' object has no attribute 'endswith'

```
  Using the `str` of the `Pattern` object solves the issue, but then looks a bit useless the [`re.compile`](https://github.com/huggingface/datatrove/blob/0f2c69f8249aa0c53ebcf10afa2394da506a953f/src/datatrove/utils/dataset.py#L95) right?
```
fs.glob(filename_pattern.pattern, maxdepth=1)

['/mloscratch/homes/solergib/nanotrove/datatrove/src/datatrove/__init__.py',
 '/mloscratch/homes/solergib/nanotrove/datatrove/src/datatrove/data.py',
 '/mloscratch/homes/solergib/nanotrove/datatrove/src/datatrove/io.py']
```

I'm using `re==2.2.1` & `fsspec==2024.3.1`!

2. Should we take care of closing the [opened files](https://github.com/huggingface/datatrove/blob/0f2c69f8249aa0c53ebcf10afa2394da506a953f/src/datatrove/utils/dataset.py#L51)?
3. It's cool to loop back to the beginning of the dataset if we index a position greater than `len(dataset)` but I can't see when this will happen if both `__len__` methods of `DatatroveFolderDataset` & `DatatroveFileDataset` return the real length (Used by the sampler for example). Maybe we are hiding indexing positions out of bounds, right?