### PR TITLE
Add label_only option to LanguageFilter

### DIFF
--- a/src/datatrove/pipeline/filters/language_filter.py
+++ b/src/datatrove/pipeline/filters/language_filter.py
@@ -17,6 +17,7 @@ class LanguageFilter(BaseFilter):
         languages: tuple = (Languages.english,),
         language_threshold: float = 0.65,
         exclusion_writer: DiskWriter = None,
+        label_only: bool = False,
     ):
         """
         filters if the predicted language is not among given language or if the language score is below language
@@ -26,10 +27,12 @@ class LanguageFilter(BaseFilter):
             languages: list of languages to keep
             language_threshold: language_threshold minimum score to accept a document
             exclusion_writer:
+            label_only: if True, only the language label is added to the metadata
         """
         super().__init__(exclusion_writer)
         self.language_threshold = language_threshold
         self.languages = languages
+        self.label_only = label_only
         self._model = None
 
     @property
@@ -59,4 +62,4 @@ class LanguageFilter(BaseFilter):
         language = language[0].split("__")[2]
         doc.metadata["language"] = language
         doc.metadata["language_score"] = score[0]
-        return score > self.language_threshold and language in self.languages
+        return self.label_only or (score > self.language_threshold and language in self.languages)

--- a/src/datatrove/pipeline/filters/language_filter.py
+++ b/src/datatrove/pipeline/filters/language_filter.py
@@ -27,7 +27,7 @@ class LanguageFilter(BaseFilter):
             languages: list of languages to keep
             language_threshold: language_threshold minimum score to accept a document
             exclusion_writer:
-            label_only: if True, only the language label is added to the metadata
+            label_only: if True, only the language label is added to the metadata and no documents are removed
         """
         super().__init__(exclusion_writer)
         self.language_threshold = language_threshold


### PR DESCRIPTION
Follow up # 136

When we set `label_only = True` , this language_filter do not filter but detect language and update language & language_score.

Building on this, I propose we add a new feature to enhance our language analysis capabilities (It's similar stats function with #136 )

The core idea is to introduce a separate block within datatrove dedicated to displaying language statistics. This would not only include the distribution of languages but also provide essential statistics which could be immensely valuable for multi-language processing.

Before moving forward with the development of this feature, I am eager to gather input and insights from the team. 