### PR TITLE
Fixes text normalization

### DIFF
--- a/src/datatrove/utils/text.py
+++ b/src/datatrove/utils/text.py
@@ -57,21 +57,23 @@ def simplify_text(text: str, config=DEF_TEXT_NORM_CONFIG) -> str:
     # We should apply the transformation in such order so that, we do same transformations
     # incrementaly as we would do if we applied each from scratch.
     # Eg.
-    # 1|2|3 -> 000 in 1-char-transform first
-    # 1|2|3 -> 0 in 1-char-transform last
+    # 1|2|3 -> 000
+    # vs
+    # 1|2|3 -> 0
 
     # lower case
     if config.lowercase:
         text = text.lower()
-    # convert punctuation to spaces
-    if config.remove_punctuation:
-        text = text.translate(PUNCTUATION_TRANS)
     if config.norm_numbers:
         text = NUMBERS_PATTERN.sub("0", text)
     if config.norm_weekdays:
         text = WEEKDAYS_PATTERN.sub("WEEKDAY", text)
     if config.norm_monthnames:
         text = MONTHS_PATTERN.sub("MONTH", text)
+
+    # convert punctuation to spaces
+    if config.remove_punctuation:
+        text = text.translate(PUNCTUATION_TRANS)
 
     # remove consecutive spaces, newlines, tabs in the middle and in the beginning / end
     if config.norm_whitespace:

--- a/src/datatrove/utils/text.py
+++ b/src/datatrove/utils/text.py
@@ -30,7 +30,7 @@ class TextNormConfig:
 
 
 DEF_TEXT_NORM_CONFIG = TextNormConfig()
-NUMBERS_PATTERN = re.compile(r"\d+")
+NUMBERS_PATTERN = re.compile(r"\d+(\.\d+)?")
 WHITESPACE_PATTERN = re.compile(r"\s+")
 # WARNING: english specific
 WEEKDAYS_PATTERN = re.compile(r"monday|tuesday|wednesday|thursday|friday|saturday|sunday")

--- a/tests/pipeline/test_text.py
+++ b/tests/pipeline/test_text.py
@@ -1,0 +1,20 @@
+import unittest
+
+from src.datatrove.utils.text import PUNCTUATION, TextNormConfig, simplify_text
+
+
+class TestTextTransformation(unittest.TestCase):
+    def test_text_table_norm(self):
+        text = "|$17.56||1|\n|$15.37||2599|"
+        config = TextNormConfig(norm_numbers=True, remove_punctuation=True, norm_whitespace=True)
+        transformed_text = simplify_text(text, config)
+        expected_text = "0 0 0 0"
+        self.assertEqual(transformed_text, expected_text)
+
+    def test_punc_normalization(self):
+        text = PUNCTUATION
+        config = TextNormConfig(remove_punctuation=True)
+        transformed_text = simplify_text(text, config)
+        # Should be just 0, because there is a strange 1 in special symbols
+        expected_text = "0"
+        self.assertEqual(transformed_text, expected_text)


### PR DESCRIPTION
Previously the text normalization was extensively destructive due to order of transformation applied.
Eg. `1|2|300$` was transformed to `0`, this means that for many deduplication uses all table lines will be equal.

This PR partially fixes it by both:
1. First applying contextual transformation (multi-char)
2. Converting punctuations to whitespaces instead of directly deleting them.

The new transformation result in `0 0 0`