### PR TITLE
Implement zstd Compression Support for JSONL and Parquet Files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ io = [
   "python-magic",
   "warcio",
   "datasets>=2.18.0",
-  "orjson"
+  "orjson",
+  "zstandard"
 ]
 s3 = [
   "s3fs>=2023.12.2",

--- a/src/datatrove/pipeline/writers/disk_base.py
+++ b/src/datatrove/pipeline/writers/disk_base.py
@@ -42,6 +42,8 @@ class DiskWriter(PipelineStep, ABC):
         output_filename = output_filename or self.default_output_filename
         if self.compression == "gzip" and not output_filename.endswith(".gz"):
             output_filename += ".gz"
+        elif self.compression == "zstd" and not output_filename.endswith(".zstd"):
+            output_filename += ".zstd"
         self.max_file_size = max_file_size
         self.file_id_counter = Counter()
         if self.max_file_size > 0 and mode != "wb":

--- a/src/datatrove/pipeline/writers/disk_base.py
+++ b/src/datatrove/pipeline/writers/disk_base.py
@@ -40,14 +40,13 @@ class DiskWriter(PipelineStep, ABC):
         self.compression = compression
         self.output_folder = get_datafolder(output_folder)
         output_filename = output_filename or self.default_output_filename
-        if self.compression == "gzip" and not output_filename.endswith(".gz"):
+        if output_filename.endswith(".parquet") and compression != "none":
+            output_filename = output_filename.replace(".parquet", f".{compression}.parquet")
+            compression = None  # compression is already handled by ParquetWriter
+        elif self.compression == "gzip" and not output_filename.endswith(".gz"):
             output_filename += ".gz"
         elif self.compression == "zstd" and not output_filename.endswith(".zstd"):
-            if output_filename.endswith(".parquet"):
-                output_filename = output_filename.replace(".parquet", ".zstd.parquet")
-                compression = None  # compression is already handled by ParquetWriter
-            else:
-                output_filename += ".zstd"
+            output_filename += ".zstd"
         self.max_file_size = max_file_size
         self.file_id_counter = Counter()
         if self.max_file_size > 0 and mode != "wb":

--- a/src/datatrove/pipeline/writers/disk_base.py
+++ b/src/datatrove/pipeline/writers/disk_base.py
@@ -43,7 +43,11 @@ class DiskWriter(PipelineStep, ABC):
         if self.compression == "gzip" and not output_filename.endswith(".gz"):
             output_filename += ".gz"
         elif self.compression == "zstd" and not output_filename.endswith(".zstd"):
-            output_filename += ".zstd"
+            if output_filename.endswith(".parquet"):
+                output_filename = output_filename.replace(".parquet", ".zstd.parquet")
+                compression = None  # compression is already handled by ParquetWriter
+            else:
+                output_filename += ".zstd"
         self.max_file_size = max_file_size
         self.file_id_counter = Counter()
         if self.max_file_size > 0 and mode != "wb":

--- a/src/datatrove/pipeline/writers/parquet.py
+++ b/src/datatrove/pipeline/writers/parquet.py
@@ -1,5 +1,5 @@
 from collections import Counter, defaultdict
-from typing import IO, Callable
+from typing import IO, Callable, Literal
 
 from datatrove.io import DataFolderLike
 from datatrove.pipeline.writers.disk_base import DiskWriter
@@ -14,7 +14,7 @@ class ParquetWriter(DiskWriter):
         self,
         output_folder: DataFolderLike,
         output_filename: str = None,
-        compression: str | None = None,
+        compression: Literal["none", "snappy", "gzip", "brotli", "lz4", "zstd"] | None = "none",
         adapter: Callable = None,
         batch_size: int = 1000,
         expand_metadata: bool = False,
@@ -32,6 +32,7 @@ class ParquetWriter(DiskWriter):
         self._writers = {}
         self._batches = defaultdict(list)
         self._file_counter = Counter()
+        self.compression = compression
         self.batch_size = batch_size
 
     def _on_file_switch(self, original_name, old_filename, new_filename):
@@ -62,7 +63,9 @@ class ParquetWriter(DiskWriter):
 
         if filename not in self._writers:
             self._writers[filename] = pq.ParquetWriter(
-                file_handler, schema=pa.RecordBatch.from_pylist([document]).schema
+                file_handler,
+                schema=pa.RecordBatch.from_pylist([document]).schema,
+                compression=self.compression,
             )
         self._batches[filename].append(document)
         if len(self._batches[filename]) == self.batch_size:

--- a/tests/pipeline/test_jsonl_zstd_compression.py
+++ b/tests/pipeline/test_jsonl_zstd_compression.py
@@ -28,3 +28,19 @@ class TestZstdCompression(unittest.TestCase):
             assert read_doc == original
             c += 1
         assert c == len(data)
+
+    # def test_parquet_writer_reader(self):
+    #     data = [
+    #         Document(text=text, id=str(i), metadata={"somedata": 2 * i, "somefloat": i * 0.4, "somestring": "hello"})
+    #         for i, text in enumerate(["hello", "text2", "more text"])
+    #     ]
+    #     with ParquetWriter(output_folder=self.tmp_dir, compression="zstd") as w:
+    #         for doc in data:
+    #             w.write(doc)
+    #     reader = ParquetReader(self.tmp_dir)
+    #     c = 0
+    #     for read_doc, original in zip(reader(), data):
+    #         read_doc.metadata.pop("file_path", None)
+    #         assert read_doc == original
+    #         c += 1
+    #     assert c == len(data)

--- a/tests/pipeline/test_parquet_zstd_compression.py
+++ b/tests/pipeline/test_parquet_zstd_compression.py
@@ -1,0 +1,30 @@
+import shutil
+import tempfile
+import unittest
+
+from datatrove.data import Document
+from datatrove.pipeline.readers.parquet import ParquetReader
+from datatrove.pipeline.writers.parquet import ParquetWriter
+
+
+class TestZstdCompression(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary directory
+        self.tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp_dir)
+
+    def test_parquet_writer_reader(self):
+        data = [
+            Document(text=text, id=str(i), metadata={"somedata": 2 * i, "somefloat": i * 0.4, "somestring": "hello"})
+            for i, text in enumerate(["hello", "text2", "more text"])
+        ]
+        with ParquetWriter(output_folder=self.tmp_dir, compression="zstd") as w:
+            for doc in data:
+                w.write(doc)
+        reader = ParquetReader(self.tmp_dir)
+        c = 0
+        for read_doc, original in zip(reader(), data):
+            read_doc.metadata.pop("file_path", None)
+            assert read_doc == original
+            c += 1
+        assert c == len(data)

--- a/tests/pipeline/test_zstd_compression.py
+++ b/tests/pipeline/test_zstd_compression.py
@@ -1,0 +1,30 @@
+import shutil
+import tempfile
+import unittest
+
+from datatrove.data import Document
+from datatrove.pipeline.readers.jsonl import JsonlReader
+from datatrove.pipeline.writers.jsonl import JsonlWriter
+
+
+class TestZstdCompression(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary directory
+        self.tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp_dir)
+
+    def test_jsonl_writer_reader(self):
+        data = [
+            Document(text=text, id=str(i), metadata={"somedata": 2 * i, "somefloat": i * 0.4, "somestring": "hello"})
+            for i, text in enumerate(["hello", "text2", "more text"])
+        ]
+        with JsonlWriter(output_folder=self.tmp_dir, compression="zstd") as w:
+            for doc in data:
+                w.write(doc)
+        reader = JsonlReader(self.tmp_dir, compression="zstd")
+        c = 0
+        for read_doc, original in zip(reader(), data):
+            read_doc.metadata.pop("file_path", None)
+            assert read_doc == original
+            c += 1
+        assert c == len(data)


### PR DESCRIPTION
Support for zstd compression in both JSONL and Parquet file formats. 

Parquet Files:
 - The implementation applies compression directly within the internal write function (pq.ParquetWriter) using the compression option.
 - To maintain clarity and avoid redundancy in DiskWriter implementation, we continue to pass the compression option at the top level but set compression=None in the actual DiskWriter call. This ensures that DiskWriter does not attempt to compress already compressed data.
 - Despite specifying the compression option in ParquetWriter, it is feasible to pass super().__init__(compression=None) to control behavior from a higher abstraction level. This design choice allows flexibility depending on how users might want to integrate or extend our functionality.

Filename Convention:
 - For clarity and standardization, files processed with zstd compression are named with the suffix {file_name}.zstd.parquet (or .zstd.jsonl), aligning with typical conventions and aiding in clear differentiation of compressed files.
 - If the file extension is set to .parquet.zstd, the pq.ParquetFile function fails to properly recognize and read the file. To ensure seamless integration and functionality, the recommended file naming convention is {file_name}.zstd.parquet, which has been tested and confirmed to work effectively with our current setup. 
