### PR TITLE
add dependencies lid.py, io.py #239

### DIFF
--- a/src/datatrove/io.py
+++ b/src/datatrove/io.py
@@ -11,6 +11,7 @@ from fsspec.implementations.local import LocalFileSystem
 from huggingface_hub import HfFileSystem, cached_assets_path
 
 from datatrove.utils.logging import logger
+from datatrove.utils._import_utils import check_required_dependencies
 
 
 class OutputFileManager:
@@ -319,6 +320,7 @@ def safely_create_file(file_to_lock: str, do_processing: Callable):
         file_to_lock: str: lock will be "lock_path.lock" and completed file "lock_path.completed"
         do_processing: callback with the code to run to process/create the files
     """
+    check_required_dependencies("io", ["fasteners"])
     from fasteners import InterProcessLock
 
     completed_file = f"{file_to_lock}.completed"

--- a/src/datatrove/utils/lid.py
+++ b/src/datatrove/utils/lid.py
@@ -2,6 +2,7 @@ from abc import abstractmethod
 
 from datatrove.data import Document
 from datatrove.io import cached_asset_path_or_download
+from datatrove.utils._import_utils import check_required_dependencies
 
 
 class LID:
@@ -37,6 +38,7 @@ class FastTextLID(LID):
     @property
     def model(self):
         if not self._model:
+            check_required_dependencies("lid", ["fasttext"])
             from fasttext.FastText import _FastText
 
             model_file = cached_asset_path_or_download(


### PR DESCRIPTION
follow up #239

+ In case of using lid, fasttext is required
+ when we use model property, we use fasteners (in io.py)  

two dependency checks added 😀.