### PR TITLE
Fix SENTINEL cluster

### DIFF
--- a/src/datatrove/pipeline/dedup/minhash.py
+++ b/src/datatrove/pipeline/dedup/minhash.py
@@ -474,8 +474,9 @@ class MinhashDedupCluster(PipelineStep):
                     file, doc = node
                     p = parent(node)
                     if node != p:
-                        output_mg.write(f"{file:06d}.remove", struct.pack("<I", doc))
-                        self.stat_update("to_remove")
+                        if file != SENTINEL:
+                            output_mg.write(f"{file:06d}.remove", struct.pack("<I", doc))
+                            self.stat_update("to_remove")
                     if self.save_cluster_id:
                         if p not in cluster_ids:
                             cluster_ids[p] = ci

--- a/src/datatrove/pipeline/dedup/minhash.py
+++ b/src/datatrove/pipeline/dedup/minhash.py
@@ -481,8 +481,9 @@ class MinhashDedupCluster(PipelineStep):
                             cluster_ids[p] = ci
                             ci += 1
                             self.stat_update("clusters")
-                        output_mg.write(f"{file:06d}.clusters", struct.pack("<I", doc))
-                        output_mg.write(f"{file:06d}.clusters", struct.pack("<I", cluster_ids[p]))
+                        if file != SENTINEL:
+                            output_mg.write(f"{file:06d}.clusters", struct.pack("<I", doc))
+                            output_mg.write(f"{file:06d}.clusters", struct.pack("<I", cluster_ids[p]))
 
 
 class MinhashDedupFilter(PipelineStep):


### PR DESCRIPTION
We do not want to store cluster_id for sentinel point, since it is not in the current data to process