### PR TITLE
Add token and char count to histogram stats

### DIFF
--- a/src/datatrove/pipeline/stats/base.py
+++ b/src/datatrove/pipeline/stats/base.py
@@ -59,10 +59,16 @@ class BaseStats(PipelineStep):
         """
         raise NotImplementedError()
 
-    def get_kv(self, doc: Document, value: STAT_TYPE, group_name: GROUP) -> tuple[str, STAT_TYPE]:
+    def get_kv(
+        self, doc: Document, value: STAT_TYPE, group_name: GROUP
+    ) -> tuple[str, STAT_TYPE | dict[str, STAT_TYPE]]:
         if group_name == "histogram":
             # Use rounding to reduce then number of values for histogram
-            return str(round(value, self.histogram_round_digits)), 1
+            return str(round(value, self.histogram_round_digits)), {
+                "": 1,
+                "chars": len(doc.text),
+                **({"tokens": doc.metadata["token_count"]} if "token_count" in doc.metadata else {}),
+            }
         elif group_name == "summary":
             return "summary", value
         elif group_name == "fqdn":
@@ -96,7 +102,13 @@ class BaseStats(PipelineStep):
                 for group, counters in groups_dicts.items():
                     for stat, value in doc_stats.items():
                         key, value = self.get_kv(doc, value, group)
-                        counters[stat][key] += value
+                        if not isinstance(value, dict):
+                            counters[stat][key] += value
+                        else:
+                            # each key in this dictionary is a suffix for the main stat
+                            for suffix, val in value.items():
+                                stat_name = stat if not suffix else f"{stat}_{suffix}"
+                                counters[stat_name][key] += val
 
                 doc.metadata.update(doc_stats)
             yield doc

--- a/src/datatrove/pipeline/stats/base.py
+++ b/src/datatrove/pipeline/stats/base.py
@@ -107,7 +107,7 @@ class BaseStats(PipelineStep):
                         else:
                             # each key in this dictionary is a suffix for the main stat
                             for suffix, val in value.items():
-                                stat_name = stat if not suffix else f"{stat}_{suffix}"
+                                stat_name = stat if not suffix else f"{stat}__{suffix}"
                                 counters[stat_name][key] += val
 
                 doc.metadata.update(doc_stats)

--- a/src/datatrove/pipeline/stats/merger.py
+++ b/src/datatrove/pipeline/stats/merger.py
@@ -71,8 +71,6 @@ class StatsMerger(PipelineStep):
 
                 with self.output_folder.open(f"{folder}/{STATS_MERGED_NAME}", "wt") as f:
                     group_name = Path(folder).parent.name
-                    if "__" in group_name:
-                        group_name = group_name.split("__")[0]
                     if group_name in self.top_k_config.top_k_groups:
                         top_k_keys = heapq.nlargest(self.top_k_config.top_k, stat, key=lambda x: stat.get(x).n)
                         stat = MetricStatsDict(init={s: stat.get(s) for s in top_k_keys})

--- a/src/datatrove/pipeline/stats/merger.py
+++ b/src/datatrove/pipeline/stats/merger.py
@@ -71,6 +71,8 @@ class StatsMerger(PipelineStep):
 
                 with self.output_folder.open(f"{folder}/{STATS_MERGED_NAME}", "wt") as f:
                     group_name = Path(folder).parent.name
+                    if "__" in group_name:
+                        group_name = group_name.split("__")[0]
                     if group_name in self.top_k_config.top_k_groups:
                         top_k_keys = heapq.nlargest(self.top_k_config.top_k, stat, key=lambda x: stat.get(x).n)
                         stat = MetricStatsDict(init={s: stat.get(s) for s in top_k_keys})


### PR DESCRIPTION
Adds 2 new stats per original stat when histogram stats are collected:
- `originalname__chars`: number of chars
- `originalname__tokens`: number of tokens (if `metadata["token_count"]` is defined)