### PR TITLE
Use spaCy tokenizer for Dutch

### DIFF
--- a/src/datatrove/utils/word_tokenizers.py
+++ b/src/datatrove/utils/word_tokenizers.py
@@ -222,7 +222,7 @@ WORD_TOKENIZER_FACTORY: dict[str, Callable[[], WordTokenizer]] = {
     Languages.french: lambda: NLTKTokenizer("french"),
     Languages.czech: lambda: NLTKTokenizer("czech"),
     Languages.danish: lambda: NLTKTokenizer("danish"),
-    Languages.dutch: lambda: NLTKTokenizer("dutch"),
+    Languages.dutch: lambda: SpaCyTokenizer("nl"),
     Languages.estonian: lambda: NLTKTokenizer("estonian"),
     Languages.finnish: lambda: NLTKTokenizer("finnish"),
     Languages.greek: lambda: NLTKTokenizer("greek"),


### PR DESCRIPTION
Dutch a relatively hard language to tokenize, especially when it comes to the possessive. From my testing in the past, I do prefer spaCy's tokenization though, as it does not have the stronger tendency (like NLTK) to split off an apostrophe when it is part of the possessive.

```
from datatrove.utils.word_tokenizers import SpaCyTokenizer, NLTKTokenizer

tokenizer = SpaCyTokenizer("nl")

print(tokenizer.word_tokenize("Ik eet die graag 's morgens. 's Anderdaags zie ik oma's kippen in Belgiës troeven. Dante’s hel en Louis’ honden."))
# ['Ik', 'eet', 'die', 'graag', "'s", 'morgens', '.', "'s", 'Anderdaags', 'zie', 'ik', "oma's", 'kippen', 'in', 'Belgiës', 'troeven', '.', 'Dante', '’s', 'hel', 'en', 'Louis', '’', 'honden', '.']


tokenizer = NLTKTokenizer("dutch")
print(tokenizer.word_tokenize("Ik eet die graag 's morgens. 's Anderdaags zie ik oma's kippen in Belgiës troeven. Dante’s hel en Louis’ honden."))
# ['Ik', 'eet', 'die', 'graag', "'s", 'morgens', '.', "'s", 'Anderdaags', 'zie', 'ik', 'oma', "'s", 'kippen', 'in', 'Belgiës', 'troeven', '.', 'Dante', '’', 's', 'hel', 'en', 'Louis', '’', 'honden', '.']
```

Neither of these are perfect but I prefer the spaCy one.