### PR TITLE
Fixed a bug that in the reader pipline, the document count is always less that the actual number of documents by the number of files.

### DIFF
--- a/src/datatrove/pipeline/readers/base.py
+++ b/src/datatrove/pipeline/readers/base.py
@@ -200,6 +200,9 @@ class BaseDiskReader(BaseReader):
                     doc_pbar.update()
                     li += 1
                 file_pbar.update()
+                # document count is non-zero, increment di and store the number
+                # of documents instead of the index of the last document
+                di += min(di, 1)
                 self.stat_update("documents", value=di, unit="input_file")
                 if self.limit != -1 and li >= self.limit:
                     break

--- a/src/datatrove/pipeline/readers/base.py
+++ b/src/datatrove/pipeline/readers/base.py
@@ -190,6 +190,7 @@ class BaseDiskReader(BaseReader):
                 self.stat_update("input_files")
                 logger.info(f"Reading input file {filepath}, {i+1}/{len(shard)}")
                 di = 0
+                ndocs = 0
                 for di, document in enumerate(self.read_file(filepath)):
                     if skipped < self.skip:
                         skipped += 1
@@ -199,11 +200,9 @@ class BaseDiskReader(BaseReader):
                     yield document
                     doc_pbar.update()
                     li += 1
+                    ndocs += 1
                 file_pbar.update()
-                # document count is non-zero, increment di and store the number
-                # of documents instead of the index of the last document
-                di += min(di, 1)
-                self.stat_update("documents", value=di, unit="input_file")
+                self.stat_update("documents", value=ndocs, unit="input_file")
                 if self.limit != -1 and li >= self.limit:
                     break
 


### PR DESCRIPTION
I came across this bug where I was running comparison of datasets of same number of documents but split into different shards. After inspection of the code, I found that in the code below the number got sent into the documents stat is actually the index of the last docuemnt in a given file, which is less than the number of documents in the file by 1.

https://github.com/huggingface/datatrove/blob/c2fc90213db55afc1c3dcb8d9210b273d9b38d6c/src/datatrove/pipeline/readers/base.py#L193-L204

Therefore, I'm proposing a simple fix that just increment the variable `di` when it's non-zero.