### PR TITLE
Fix languages listify bug

### DIFF
--- a/src/datatrove/pipeline/filters/language_filter.py
+++ b/src/datatrove/pipeline/filters/language_filter.py
@@ -33,7 +33,7 @@ class LanguageFilter(BaseFilter):
         super().__init__(exclusion_writer)
         self.language_threshold = language_threshold
         if isinstance(languages, str):
-            languages = list(languages)
+            languages = [languages]
         self.languages = languages
         self.backend = backend
         self.model = FT176LID(languages) if backend == "ft176" else GlotLID(languages)


### PR DESCRIPTION
If the passed language is a string, it should be turned into a list like this `[languages]` rather than `list(languages)`. The latter will turn a string into a list of its individual characters.

```
>>> list("en")
['e', 'n']
>>> ["en"]
['en']
```