### PR TITLE
[Fixbug] Ensure only one task will be launched for each srun cmd

### DIFF
--- a/src/datatrove/executor/slurm.py
+++ b/src/datatrove/executor/slurm.py
@@ -257,7 +257,9 @@ class SlurmPipelineExecutor(PipelineExecutor):
         srun_args_str = " ".join([f"--{k}={v}" for k, v in self.srun_args.items()]) if self.srun_args else ""
         launch_file_contents = self.get_launch_file_contents(
             self.get_sbatch_args(max_array),
-            f"srun {srun_args_str} -l launch_pickled_pipeline {self.logging_dir.resolve_paths('executor.pik')}",
+            # use "-n 1" for each srun command to enforce that only one task will be launched.
+            # Some setting may lead to two tasks, see https://groups.google.com/g/slurm-users/c/L4nCXtZLlTo
+            f"srun {srun_args_str} -l -n 1 launch_pickled_pipeline {self.logging_dir.resolve_paths('executor.pik')}",
         )
         # save it
         with self.logging_dir.open("launch_script.slurm", "w") as launchscript_f:


### PR DESCRIPTION
Some slurm setting will launch multiple tasks for a single srun command. Especially when `--cpus-per-task=1` is used in the sbatch script. 

```bash
$ srun --cpus-per-task=1 --partition=gpu-2080ti echo foo
srun: job 1298286 queued and waiting for resources
srun: job 1298286 has been allocated resources
foo
foo
```

See more detailed discussions [here](https://groups.google.com/g/slurm-users/c/L4nCXtZLlTo)

This behavior is lethal to some tasks if these tasks read and write files. A same set of files will be modified at the same time, which will lead to errors.

It is better to enforce only one task is executed for each srun command.