### PR TITLE
load_tokenizer can now load local hf folder

### DIFF
--- a/src/datatrove/utils/tokenization.py
+++ b/src/datatrove/utils/tokenization.py
@@ -15,8 +15,9 @@ if TYPE_CHECKING:
 def load_tokenizer(name_or_path: str) -> "Tokenizer":
     from tokenizers import Tokenizer
 
-    if os.path.exists(name_or_path):
+    if os.path.isfile(name_or_path):
         return Tokenizer.from_file(name_or_path)
+
     return Tokenizer.from_pretrained(name_or_path)
 
 


### PR DESCRIPTION
The `load_tokenizer` function assumed that if a path exists, it should be loaded with `from_file`, so it failed to load a Hugging Face folder that was saved locally. This should hopefully fix that.