### PR TITLE
[fixbug]: Fixed the issue in MinhashBuildIndex where get_datafolder w…

### DIFF
--- a/src/datatrove/pipeline/dedup/minhash.py
+++ b/src/datatrove/pipeline/dedup/minhash.py
@@ -574,8 +574,8 @@ class MinhashBuildIndex(PipelineStep):
         lines_to_buffer: int = 5,
     ):
         super().__init__()
-        self.input_folder = input_folder
-        self.output_folder = output_folder
+        self.input_folder = get_datafolder(input_folder)
+        self.output_folder = get_datafolder(output_folder)
         self.config = config or MinhashConfig()
         self.index_name = index_name
         self.lines_to_buffer = lines_to_buffer


### PR DESCRIPTION
Fixed the issue in MinhashBuildIndex where get_datafolder was not used to obtain DataFolder for input_folder and output_folder.

In the original code, if a string or tuple type input was passed, an exception would be raised when reading the related files. This was caused by not properly using get_datafolder to obtain the DataFolder type.