### PR TITLE
fix(utils): Enhance the dependencies check to include pip distribution

### DIFF
--- a/src/datatrove/pipeline/filters/fasttext_filter.py
+++ b/src/datatrove/pipeline/filters/fasttext_filter.py
@@ -36,7 +36,7 @@ class FastTextClassifierFilter(BaseFilter):
     """
 
     name = "🤖 fastText"
-    _requires_dependencies = [("fasttext", "fasttext-wheel"), "fasteners"]
+    _requires_dependencies = [("fasttext", "fasttext-numpy2-wheel"), "fasteners"]
 
     def __init__(
         self,

--- a/src/datatrove/pipeline/filters/language_filter.py
+++ b/src/datatrove/pipeline/filters/language_filter.py
@@ -8,7 +8,7 @@ from datatrove.utils.lid import FT176LID, GlotLID
 
 class LanguageFilter(BaseFilter):
     name = "🌍 Language ID"
-    _requires_dependencies = [("fasttext", "fasttext-wheel"), "fasteners"]
+    _requires_dependencies = [("fasttext", "fasttext-numpy2-wheel"), "fasteners"]
 
     def __init__(
         self,

--- a/src/datatrove/utils/_import_utils.py
+++ b/src/datatrove/utils/_import_utils.py
@@ -82,10 +82,11 @@ def is_tokenizers_available():
 
 
 # Distribution Check
+@lru_cache
 def _is_distribution_available(distribution_name: str):
     found = None
     for dist in importlib.metadata.distributions():
-        if dist.metadata["Name"] == distribution_name:
+        if dist.metadata["Name"] and dist.metadata["Name"].lower() == distribution_name:
             found = True
     return found
 

--- a/src/datatrove/utils/lid.py
+++ b/src/datatrove/utils/lid.py
@@ -38,7 +38,7 @@ class FastTextLID(LID):
     @property
     def model(self):
         if self._model is None:
-            check_required_dependencies("lid", [("fasttext", "fasttext-wheel")])
+            check_required_dependencies("lid", [("fasttext", "fasttext-numpy2-wheel")])
             from fasttext.FastText import _FastText
 
             model_file = cached_asset_path_or_download(


### PR DESCRIPTION
With the 0.4.0 release, Datatrove transitioned to numpy 2.0, and the [pyproject.toml ](https://github.com/huggingface/datatrove/blob/2548cdfaacb5e77d1fc4cf1403c8d643c7996090/pyproject.toml#L52)was updated to ensure that the version of fasttext used is compatible with numpy 2.x.

However, if users do not start with a totally new virtual environment and just continue using `fasttext-wheels` compatible with numpy 1.x, we check only verifies the module name `fasttext`, which can cause an [error](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword) to be raised during execution.

To solve this issue, I modfied below:
+ add `_is_distribution_available` in `_import_utils` to strictly manage pip distributions. 
+ modified the `check_required_dependencies` function to perform above.
+ also modified [lid](https://github.com/huggingface/datatrove/blob/v0.4.0/src/datatrove/utils/lid.py#L41), [language_filter](https://github.com/huggingface/datatrove/blob/v0.4.0/src/datatrove/pipeline/filters/language_filter.py#L11), [fasttext_filter](https://github.com/huggingface/datatrove/blob/v0.4.0/src/datatrove/pipeline/filters/fasttext_filter.py) to check pip distribution `fasttext-numpy2-wheel`

During pytest, an error related to the Tibetan language occurred, but since it is not relevant to my region, I did not make any additional changes.