### PR TITLE
Add customization for fetching SLURM job id

### DIFF
--- a/src/datatrove/executor/slurm.py
+++ b/src/datatrove/executor/slurm.py
@@ -10,6 +10,7 @@ import tempfile
 import textwrap
 import time
 from copy import deepcopy
+from functools import partial
 from typing import Callable
 
 import dill

--- a/src/datatrove/executor/slurm.py
+++ b/src/datatrove/executor/slurm.py
@@ -63,6 +63,9 @@ class SlurmPipelineExecutor(PipelineExecutor):
         depends_job_id: alternatively to the above, you can pass the job id of a dependency
         job_id_position: position of job ID in custom Sbatch outputs.
             default: -1
+        job_id_retriever: a callable that takes the output of the sbatch command (as written to terminal)
+            as input and returns the extracted job id to be used as 'self.job_id'. Defaults to take the
+            `job_id_position`-th element from the split output. default: default_job_id_retriever
         logging_dir: where to save logs, stats, etc. Should be parsable into a datatrove.io.DataFolder
         skip_completed: whether to skip tasks that were completed in
             previous runs. default: True


### PR DESCRIPTION
SLURM job IDs are hard to fetch. The current implementation does not flexibly allow for users to retrieve the right ID based on their printed output (which may be different depending on the implementation). As an example, when submitting an sbatch job, the printed string on our system is 

> Submitted batch job 9914862 on cluster dodrio

The current default implementation simply splits this string on space and selects the last item. In my case that does not make sense, so it greatly depends on how this info is printed.

I therefore suggest to allow the pipeline constructor to have a `job_id_retriever` Callable argument. Default behavior is the same as it is now. However, if a user provides a callable, they can choose how the process output is returned.

So in my case, I would add

```python
def job_id_retriever(job_id: str) -> str:
    return re.search(r"Submitted batch job (\d+)", job_id).group(1)

SlurmPipelineExecutor(
    ...,
    job_id_retriever=job_id_retriever,
    ...
)
```

This funcion will be used to postprocess the retrieved submission text.

As said, the default behavior is the same.
