### PR TITLE
Fix issues with URL Deduplication when using the Index

### DIFF
--- a/tests/pipeline/test_sentence_deduplication.py
+++ b/tests/pipeline/test_sentence_deduplication.py
@@ -8,6 +8,7 @@ import unittest
 from datatrove.data import Document
 from datatrove.pipeline.dedup.sentence_dedup import (
     SentDedupConfig,
+    SentenceDedupBuildIndex,
     SentenceDedupFilter,
     SentenceDedupSignature,
     SentenceFindDedups,
@@ -109,6 +110,11 @@ DOCS_2 = [
     Document(text=TEXT_1_1, id="6"),
 ]
 
+INDEX = [
+    Document(text=TEXT_0, id="0"),
+    Document(text=LOTR, id="1"),
+]
+
 TARGETS = [
     TEXT_0,
     EXPECTED_TEXT_1,
@@ -134,6 +140,13 @@ TARGETS_WS2_1 = [
     TEXT_3_1,
 ]
 
+TARGETS_WITH_INDEX = [
+    EXPECTED_TEXT_1,
+    rs_1,
+    " ".join([rs_1, rs_2]),
+    HPPS,
+]
+
 
 @require_nltk
 @require_xxhash
@@ -155,6 +168,30 @@ class SentenceDedup(unittest.TestCase):
         find_duplicates()
         for i, doc in enumerate(dedup_filter(data=copy.deepcopy(DOCS))):
             self.assertEqual(doc.text, TARGETS[i])
+
+    def test_sd_with_index(self):
+        config = SentDedupConfig(min_doc_words=0, min_num_sentences=0)
+        signature_creation = SentenceDedupSignature(output_folder=self.tmp_dir + "/sigs", config=config)
+        index_signature_creation = SentenceDedupSignature(output_folder=self.tmp_dir + "/index_sigs", config=config)
+        build_index = SentenceDedupBuildIndex(
+            data_folder=self.tmp_dir + "/index_sigs",
+            output_folder=self.tmp_dir + "/index",
+            index_name="index",
+        )
+        find_duplicates = SentenceFindDedups(
+            data_folder=self.tmp_dir + "/sigs",
+            index_folder=self.tmp_dir + "/index",
+            output_folder=self.tmp_dir + "/dups",
+            config=config,
+        )
+        dedup_filter = SentenceDedupFilter(data_folder=self.tmp_dir + "/dups", config=config)
+
+        index_signature_creation(data=INDEX)
+        build_index()
+        signature_creation(data=DOCS)
+        find_duplicates()
+        for i, doc in enumerate(dedup_filter(data=copy.deepcopy(DOCS))):
+            self.assertEqual(doc.text, TARGETS_WITH_INDEX[i])
 
     def test_sd_worker(self):
         config = SentDedupConfig(min_doc_words=0, min_num_sentences=0)

--- a/tests/pipeline/test_url_deduplication.py
+++ b/tests/pipeline/test_url_deduplication.py
@@ -22,6 +22,11 @@ DOCS = [
     Document(text="", metadata={"url": "https://example2.com"}, id="5"),
 ]
 
+INDEX = [
+    Document(text="", metadata={"url": "https://example.com"}, id="1"),
+    Document(text="", metadata={"url": "https://example2.com"}, id="2"),
+]
+
 DOCS_1 = DOCS[:2]
 DOCS_2 = DOCS[2:]
 
@@ -127,15 +132,15 @@ class UrlDedup(unittest.TestCase):
         )
         dedup_filter = UrlDedupFilter(data_folder=self.tmp_dir + "/dups")
 
-        index_signature_creation(data=DOCS[:1])
+        index_signature_creation(data=INDEX)
         build_index()
-        signature_creation(data=DOCS[1:])
+        signature_creation(data=DOCS)
         find_duplicates()
-        docs = list(dedup_filter(data=copy.deepcopy(DOCS[1:])))
-        self.assertEqual(len(docs), 2)
+        docs = list(dedup_filter(data=copy.deepcopy(DOCS)))
+        self.assertEqual(len(docs), 1)
         self.assertEqual(
             {doc.metadata["url"] for doc in docs},
-            {doc.metadata["url"] for doc in DOCS[1:]} - {doc.metadata["url"] for doc in DOCS[:1]},
+            {doc.metadata["url"] for doc in DOCS} - {doc.metadata["url"] for doc in INDEX},
         )
 
     def test_sd_worker(self):


### PR DESCRIPTION
I found several issues with URL deduplication using the Index and implemented fixes to resolve them.

- Index Signature Ignored: 
The HashSig in the Index must be prioritized to pop first for a given hash value.
To ensure this, the priority of the Index's HashSig should be slightly higher than the maximum priority value of 65,536.

- The Index should be correctly fetched from the index_folder instead of the data_folder.

- When deduplicating a list containing multiple duplicate URLs, the result may still include duplicates.
If the hash_value of `last` matches that of `v`, the update should only occur when `last` is not the HashSig of the Index.
(This issue may also exist in sentence deduplication.)