### PR TITLE
fixes stopwors implementation

### DIFF
--- a/src/datatrove/pipeline/filters/gopher_quality_filter.py
+++ b/src/datatrove/pipeline/filters/gopher_quality_filter.py
@@ -119,7 +119,7 @@ class GopherQualityFilter(BaseFilter):
             return False, "gopher_below_alpha_threshold"
 
         # stop word filter
-        if self.min_stop_words and sum(w in self.stop_words for w in words) < self.min_stop_words:
+        if self.min_stop_words and len(self.stop_words.intersection(set(words))) < self.min_stop_words:
             return False, "gopher_enough_stop_words"
 
         return True


### PR DESCRIPTION
We should check how many of the stopwords are present in the document, and not how many of the words in the document are stopwords (each stopword should only count once)