### PR TITLE
Allow custom parquet schema

### DIFF
--- a/src/datatrove/pipeline/writers/huggingface.py
+++ b/src/datatrove/pipeline/writers/huggingface.py
@@ -2,7 +2,7 @@ import os
 import random
 import tempfile
 import time
-from typing import Callable, Literal
+from typing import Any, Callable, Literal
 
 from huggingface_hub import (
     CommitOperationAdd,
@@ -11,7 +11,6 @@ from huggingface_hub import (
     preupload_lfs_files,
 )
 from huggingface_hub.utils import HfHubHTTPError
-from pyarrow.lib import Schema
 
 from datatrove.io import DataFolderLike, get_datafolder
 from datatrove.pipeline.writers import ParquetWriter
@@ -37,7 +36,7 @@ class HuggingFaceDatasetWriter(ParquetWriter):
         cleanup: bool = True,
         expand_metadata: bool = True,
         max_file_size: int = round(4.5 * 2**30),  # 4.5GB, leave some room for the last batch
-        schema: Schema = None,
+        schema: Any = None,
     ):
         """
         This class is intended to upload VERY LARGE datasets. Consider using `push_to_hub` or just using a

--- a/src/datatrove/pipeline/writers/huggingface.py
+++ b/src/datatrove/pipeline/writers/huggingface.py
@@ -11,6 +11,7 @@ from huggingface_hub import (
     preupload_lfs_files,
 )
 from huggingface_hub.utils import HfHubHTTPError
+from pyarrow.lib import Schema
 
 from datatrove.io import DataFolderLike, get_datafolder
 from datatrove.pipeline.writers import ParquetWriter
@@ -36,6 +37,7 @@ class HuggingFaceDatasetWriter(ParquetWriter):
         cleanup: bool = True,
         expand_metadata: bool = True,
         max_file_size: int = round(4.5 * 2**30),  # 4.5GB, leave some room for the last batch
+        schema: Schema = None,
     ):
         """
         This class is intended to upload VERY LARGE datasets. Consider using `push_to_hub` or just using a
@@ -73,6 +75,7 @@ class HuggingFaceDatasetWriter(ParquetWriter):
             adapter=adapter,
             expand_metadata=expand_metadata,
             max_file_size=max_file_size,
+            schema=schema,
         )
         self.operations = []
         self._repo_init = False

--- a/src/datatrove/pipeline/writers/parquet.py
+++ b/src/datatrove/pipeline/writers/parquet.py
@@ -1,7 +1,5 @@
 from collections import Counter, defaultdict
-from typing import IO, Callable, Literal
-
-from pyarrow.lib import Schema
+from typing import IO, Any, Callable, Literal
 
 from datatrove.io import DataFolderLike
 from datatrove.pipeline.writers.disk_base import DiskWriter
@@ -21,7 +19,7 @@ class ParquetWriter(DiskWriter):
         batch_size: int = 1000,
         expand_metadata: bool = False,
         max_file_size: int = 5 * 2**30,  # 5GB
-        schema: Schema = None,
+        schema: Any = None,
     ):
         # Validate the compression setting
         if compression not in {"snappy", "gzip", "brotli", "lz4", "zstd", None}:

--- a/src/datatrove/pipeline/writers/parquet.py
+++ b/src/datatrove/pipeline/writers/parquet.py
@@ -61,7 +61,7 @@ class ParquetWriter(DiskWriter):
         import pyarrow as pa
 
         # prepare batch
-        batch = pa.RecordBatch.from_pylist(self._batches.pop(filename))
+        batch = pa.RecordBatch.from_pylist(self._batches.pop(filename), schema=self.schema)
         # write batch
         self._writers[filename].write_batch(batch)
 


### PR DESCRIPTION
In my data fields I have items that can be None or string, e.g. `doc.metadata["license"] = None`. But if the first document that is written to the file has a None value, parquet will set this field's type to an explicit `null`, so when the writer tries to add a new document that has a non-null value, there will be a conflict.

Explicitly: if the first item is null, the schema will automatically be set it to `pa.null()` but if the next document has a string, it will try using `pa.string()`, which then conflicts with the previous `null()`. To avoid this, we can explicitly pass a schema that sets the type to `pa.string()` to begin with (which allows null), so that the strict `null()` is avoided altogether.

So this PR simply adds the option to pass a Schema to the ParquetWriter (and the HuggingfaceWriter). Default behavior remains the same as before.