### PR TITLE
Add RayPipelineExecutor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,10 @@ multilingual = [
     "botok", # tibetan languages,
     "pyidaungsu-numpy2", # burmese
 ]
+
+ray = [
+  "ray"
+]
 quality = [
   "ruff>=0.1.5"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ testing = [
   "datatrove[processing]",
   "datatrove[multilingual]",
   "datatrove[s3]",
+  "datatrove[ray]",
   # Lighteval doesn't support numpy>=2.0.0
 #  "datatrove[decont]",
 # Flask doesn't have correct dependencies on werkzeux, causing issues, thus we pin flask 3.1 (which currently works) to avoid it

--- a/src/datatrove/executor/__init__.py
+++ b/src/datatrove/executor/__init__.py
@@ -1,2 +1,3 @@
 from .local import LocalPipelineExecutor
+from .ray import RayPipelineExecutor
 from .slurm import SlurmPipelineExecutor

--- a/src/datatrove/executor/ray.py
+++ b/src/datatrove/executor/ray.py
@@ -1,25 +1,48 @@
 #!/usr/bin/env python3
+import random
 import time
-from typing import Callable
+from collections import deque
+from typing import Callable, Optional, Sequence
 
 import ray
 
 from datatrove.executor.base import PipelineExecutor
-from datatrove.io import DataFolderLike
+from datatrove.io import DataFolderLike, get_datafolder
 from datatrove.pipeline.base import PipelineStep
-from datatrove.utils.logging import logger
+from datatrove.utils.logging import add_task_logger, close_task_logger, log_pipeline, logger
 from datatrove.utils.stats import PipelineStats
 
 
 @ray.remote
-def _launch_run_for_rank(executor_pik, rank: int) -> PipelineStats:
+def run_for_rank(executor_ref: "RayPipelineExecutor", ranks: list[int]) -> PipelineStats:
     """
-    A Ray remote function that invokes executor_pik._run_for_rank(rank).
-    We define it at the module level so Ray can easily serialize/deserialize it.
+        Main executor's method. Sets up logging, pipes data from each pipeline step to the next, saves statistics
+        and marks tasks as completed.
+    Args:
+        executor_ref: the executor reference
+        ranks: the ranks that we want to run in this job
+    Returns: cumulative stats for all ranks in this job
     """
-    # Note: 'executor_pik' is expected to be an actual executor instance if we pass 'self',
-    # or a copy (e.g., via deepcopy) that is Ray-picklable.
-    return executor_pik._run_for_rank(rank)
+    import multiprocess.pool
+
+    from datatrove.utils.stats import PipelineStats
+
+    # Sleep for the executor's timeout
+    def run_for_rank_wrapper_with_sleep(rank, rank_id):
+        time.sleep(random.randint(0, executor_ref.randomize_start_duration))
+        return executor_ref._run_for_rank(rank, rank_id)
+
+    executor = executor_ref
+    rank_ids = list(range(len(ranks))) if executor.log_first else list(range(1, len(ranks) + 1))
+    stats = PipelineStats()
+    # We use simple map, so that all tasks are executed and errors are reported (raised) only after all tasks are finished
+    with multiprocess.pool.Pool(processes=len(ranks)) as pool:
+        # Consume results
+        deque(
+            pool.starmap(run_for_rank_wrapper_with_sleep, [(rank, rank_id) for rank_id, rank in zip(rank_ids, ranks)]),
+            maxlen=0,
+        )
+    return stats
 
 
 class RayPipelineExecutor(PipelineExecutor):
@@ -38,12 +61,14 @@ class RayPipelineExecutor(PipelineExecutor):
             previous runs. default: True
         logging_dir: where to save logs, stats, etc. Should be parsable into a datatrove.io.DataFolder
         randomize_start_duration: the maximum number of seconds to delay the start of each task.
-        num_cpus_per_task: The number of CPUs to reserve per rank/task
+        cpus_per_task: The number of CPUs to reserve per task
             in the Ray cluster. Defaults to 1.
-        memory_bytes_per_task: Amount of memory (in bytes) to reserve per rank/task
+        mem_per_cpu_gb: Amount of memory (in GB) to reserve per CPU
             in the Ray cluster. Defaults to 2 GB.
-        num_gpus_per_task: The number of GPUs to reserve per rank/task in the
-            Ray cluster. Defaults to 0.
+        ray_remote_kwargs: Additional kwargs to pass to the ray.remote decorator
+        log_first: Whether to the first task in ray job should log to console. Default: False
+        tasks_per_job: Number of tasks to run in each Ray job. Default: 1
+        time: Optional time limit in seconds for each task
     """
 
     def __init__(
@@ -55,19 +80,24 @@ class RayPipelineExecutor(PipelineExecutor):
         skip_completed: bool = True,
         logging_dir: DataFolderLike = None,
         randomize_start_duration: int = 0,
-        num_cpus_per_task: float = 1,
-        memory_bytes_per_task: int = 2 * 1024 * 1024 * 1024,
-        num_gpus_per_task: float = 0,
+        cpus_per_task: int = 1,
+        mem_per_cpu_gb: float = 2,
+        ray_remote_kwargs: dict = None,
+        log_first: bool = False,
+        tasks_per_job: int = 1,
+        time: Optional[int] = None,
     ):
         super().__init__(pipeline, logging_dir, skip_completed, randomize_start_duration)
         self.tasks = tasks
         self.workers = workers if workers != -1 else tasks
         self.depends = depends
         # track whether run() has been called
-        self._launched = False
-        self.num_cpus_per_task = num_cpus_per_task
-        self.memory_bytes_per_task = memory_bytes_per_task
-        self.num_gpus_per_task = num_gpus_per_task
+        self.cpus_per_task = cpus_per_task
+        self.mem_per_cpu_gb = mem_per_cpu_gb
+        self.ray_remote_kwargs = ray_remote_kwargs
+        self.tasks_per_job = tasks_per_job
+        self.log_first = log_first
+        self.time = time
 
     @property
     def world_size(self) -> int:
@@ -80,20 +110,8 @@ class RayPipelineExecutor(PipelineExecutor):
 
         # 1) If there is a depends=, ensure it has run and is finished
         if self.depends:
-            if not self.depends._launched:
-                logger.info(f'Launching dependency job "{self.depends}"')
-                self.depends.run()
-
-            # Wait until the dependency has no incomplete ranks
-            while True:
-                incomplete = len(self.depends.get_incomplete_ranks())
-                if incomplete == 0:
-                    break
-                logger.info(f"Dependency job still has {incomplete}/{self.depends.world_size} tasks. Waiting...")
-                time.sleep(2 * 60)
-
-        # 2) Mark this executor as launched
-        self._launched = True
+            logger.info(f'Launching dependency job "{self.depends}"')
+            self.depends.run()
 
         # 3) Check if all tasks are already completed
         incomplete_ranks = self.get_incomplete_ranks(range(self.world_size))
@@ -106,44 +124,132 @@ class RayPipelineExecutor(PipelineExecutor):
         # 4) Save executor JSON
         self.save_executor_as_json()
 
+        executor_ref = ray.put(self)
+
         # 5) Define resource requirements for this pipeline's tasks
         remote_options = {
-            "num_cpus": self.num_cpus_per_task,
-            "num_gpus": self.num_gpus_per_task,
-            "memory": self.memory_bytes_per_task,
+            "num_cpus": self.cpus_per_task,
+            "num_gpus": 0,
+            "memory": int(self.mem_per_cpu_gb * self.cpus_per_task * 1024 * 1024 * 1024),
         }
+        if self.ray_remote_kwargs:
+            remote_options.update(self.ray_remote_kwargs)
 
         # 6) Dispatch Ray tasks
         MAX_CONCURRENT_TASKS = self.workers
+        ranks_per_jobs = [
+            incomplete_ranks[i : i + self.tasks_per_job] for i in range(0, len(incomplete_ranks), self.tasks_per_job)
+        ]
         unfinished = []
+        completed = 0
 
-        for _ in range(min(MAX_CONCURRENT_TASKS, len(incomplete_ranks))):
-            rank_to_submit = incomplete_ranks.pop()
-            unfinished.append(_launch_run_for_rank.options(**remote_options).remote(self, rank_to_submit))
+        ray_remote_func = run_for_rank.options(**remote_options)
+
+        # 7) Keep tasks start_time
+        task_start_times = {}
+        for _ in range(min(MAX_CONCURRENT_TASKS, len(ranks_per_jobs))):
+            ranks_to_submit = ranks_per_jobs.pop(0)
+            task = ray_remote_func.remote(executor_ref, ranks_to_submit)
+            unfinished.append(task)
+            task_start_times[task] = time.time()
 
         # 7) Wait for the tasks to finish, merging them as they complete.
-        total_stats = PipelineStats()
         while unfinished:
-            finished, unfinished = ray.wait(unfinished, num_returns=len(unfinished), timeout=5)
+            finished, unfinished = ray.wait(unfinished, num_returns=len(unfinished), timeout=10)
+            for task in finished:
+                # Remove task from task_start_times
+                del task_start_times[task]
+                # Remove task itself
+                del task
+
             try:
                 results = ray.get(finished)
-                for task_result in results:
-                    total_stats += task_result
+                for _ in results:
+                    completed += 1
             except Exception as e:
-                logger.exception(f"Error processing shard: {e}")
-                raise
+                logger.exception(f"Error processing rank: {e}")
 
-            # If we have more shard paths left to process and we haven't hit the max
+            # If we have more ranks left to process and we haven't hit the max
             # number of concurrent tasks, add tasks to the unfinished queue.
-            while incomplete_ranks and len(unfinished) < MAX_CONCURRENT_TASKS:
-                rank_to_submit = incomplete_ranks.pop()
-                unfinished.append(_launch_run_for_rank.options(**remote_options).remote(self, rank_to_submit))
+            while ranks_per_jobs and len(unfinished) < MAX_CONCURRENT_TASKS:
+                ranks_to_submit = ranks_per_jobs.pop(0)
+                task = ray_remote_func.remote(executor_ref, ranks_to_submit)
+                unfinished.append(task)
+                task_start_times[task] = time.time()
 
+            # Finally remove tasks that run for more than self.timeout seconds
+            if self.time:
+                for task in unfinished:
+                    if time.time() - task_start_times[task] > self.time:
+                        # No mercy :) -> should call SIGKILL
+                        ray.kill(task, force=True)
+                        del task_start_times[task]
+                        unfinished.remove(task)
+                        logger.warning(f"Task {task} timed out after {self.time} seconds and was killed.")
         logger.info("All Ray tasks have finished.")
 
-        # 8) Save merged stats
-        with self.logging_dir.open("stats.json", "wt") as statsfile:
-            total_stats.save_to_disk(statsfile)
+        # 8) Merge stats of all ranks
+        if completed == len(ranks_per_jobs):
+            total_stats = PipelineStats()
+            for rank in range(self.world_size):
+                with self.logging_dir.open(f"stats/{rank:05d}.json", "r") as f:
+                    total_stats += PipelineStats.from_json(f)
+            with self.logging_dir.open("stats.json", "wt") as statsfile:
+                total_stats.save_to_disk(statsfile)
+            logger.success(total_stats.get_repr(f"All {completed}/{self.world_size} tasks."))
+        else:
+            logger.warning(f"Only {completed}/{self.world_size} tasks completed.")
 
-        logger.success(total_stats.get_repr(f"All {len(incomplete_ranks)} tasks"))
-        return total_stats
+    def _run_for_rank(self, rank: int, local_rank: int = 0) -> PipelineStats:
+        """
+            Main executor's method. Sets up logging, pipes data from each pipeline step to the next, saves statistics
+            and marks tasks as completed.
+        Args:
+            rank: the rank that we want to run the pipeline for
+            local_rank: at the moment this is only used for logging.
+            Any task with local_rank != 0 will not print logs to console.
+
+        Returns: the stats for this task
+        """
+        if self.is_rank_completed(rank):
+            logger.info(f"Skipping {rank=} as it has already been completed.")
+            return PipelineStats()
+
+        # We log only locally and upload logs to logging_dir after the pipeline is finished
+        ray_logs_dir = get_datafolder("/tmp/ray_logs")
+        logfile = add_task_logger(ray_logs_dir, rank, local_rank)
+        log_pipeline(self.pipeline)
+
+        try:
+            # pipe data from one step to the next
+            pipelined_data = None
+            for pipeline_step in self.pipeline:
+                if callable(pipeline_step):
+                    pipelined_data = pipeline_step(pipelined_data, rank, self.world_size)
+                elif isinstance(pipeline_step, Sequence) and not isinstance(pipeline_step, str):
+                    pipelined_data = pipeline_step
+                else:
+                    raise ValueError
+            if pipelined_data:
+                deque(pipelined_data, maxlen=0)
+
+            logger.success(f"Processing done for {rank=}")
+
+            # stats
+            stats = PipelineStats(self.pipeline)
+            with self.logging_dir.open(f"stats/{rank:05d}.json", "w") as f:
+                stats.save_to_disk(f)
+            logger.info(stats.get_repr(f"Task {rank}"))
+            # completed
+            self.mark_rank_as_completed(rank)
+        except Exception as e:
+            logger.exception(e)
+            raise e
+        finally:
+            close_task_logger(logfile)
+            # Copy logs from local dir to logging_dir
+            with ray_logs_dir.open(f"logs/task_{rank:05d}.log", "r") as f, self.logging_dir.open(
+                f"logs/task_{rank:05d}.log", "w"
+            ) as f_out:
+                f_out.write(f.read())
+        return stats

--- a/src/datatrove/executor/ray.py
+++ b/src/datatrove/executor/ray.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+import time
+from typing import Callable
+
+import ray
+
+from datatrove.executor.base import PipelineExecutor
+from datatrove.io import DataFolderLike
+from datatrove.pipeline.base import PipelineStep
+from datatrove.utils.logging import logger
+from datatrove.utils.stats import PipelineStats
+
+
+@ray.remote
+def _launch_run_for_rank(executor_pik, rank: int) -> PipelineStats:
+    """
+    A Ray remote function that invokes executor_pik._run_for_rank(rank).
+    We define it at the module level so Ray can easily serialize/deserialize it.
+    """
+    # Note: 'executor_pik' is expected to be an actual executor instance if we pass 'self',
+    # or a copy (e.g., via deepcopy) that is Ray-picklable.
+    return executor_pik._run_for_rank(rank)
+
+
+class RayPipelineExecutor(PipelineExecutor):
+    """
+    Executor to run a pipeline using Ray. It's expected that the Ray cluster has already
+    been set up (e.g., via `ray.init()`) prior to invoking this pipeline.
+
+    Args:
+        pipeline: a list of PipelineStep and/or custom lamdba functions
+            with arguments (data: DocumentsPipeline, rank: int,
+            world_size: int)
+        tasks: total number of tasks to run the pipeline on (default: 1)
+        workers: how many tasks to run simultaneously. (default is -1 for no limit aka tasks)
+        depends: another PipelineExecutor that should run before this one
+        skip_completed: whether to skip tasks that were completed in
+            previous runs. default: True
+        logging_dir: where to save logs, stats, etc. Should be parsable into a datatrove.io.DataFolder
+        randomize_start_duration: the maximum number of seconds to delay the start of each task.
+        num_cpus_per_task: The number of CPUs to reserve per rank/task
+            in the Ray cluster. Defaults to 1.
+        memory_bytes_per_task: Amount of memory (in bytes) to reserve per rank/task
+            in the Ray cluster. Defaults to 2 GB.
+        num_gpus_per_task: The number of GPUs to reserve per rank/task in the
+            Ray cluster. Defaults to 0.
+    """
+
+    def __init__(
+        self,
+        pipeline: list[PipelineStep | Callable],
+        tasks: int = 1,
+        workers: int = -1,
+        depends: "RayPipelineExecutor" = None,
+        skip_completed: bool = True,
+        logging_dir: DataFolderLike = None,
+        randomize_start_duration: int = 0,
+        num_cpus_per_task: float = 1,
+        memory_bytes_per_task: int = 2 * 1024 * 1024 * 1024,
+        num_gpus_per_task: float = 0,
+    ):
+        super().__init__(pipeline, logging_dir, skip_completed, randomize_start_duration)
+        self.tasks = tasks
+        self.workers = workers if workers != -1 else tasks
+        self.depends = depends
+        # track whether run() has been called
+        self._launched = False
+        self.num_cpus_per_task = num_cpus_per_task
+        self.memory_bytes_per_task = memory_bytes_per_task
+        self.num_gpus_per_task = num_gpus_per_task
+
+    @property
+    def world_size(self) -> int:
+        return self.tasks
+
+    def run(self):
+        """
+        Run the pipeline for each rank using Ray tasks.
+        """
+
+        # 1) If there is a depends=, ensure it has run and is finished
+        if self.depends:
+            if not self.depends._launched:
+                logger.info(f'Launching dependency job "{self.depends}"')
+                self.depends.run()
+
+            # Wait until the dependency has no incomplete ranks
+            while True:
+                incomplete = len(self.depends.get_incomplete_ranks())
+                if incomplete == 0:
+                    break
+                logger.info(f"Dependency job still has {incomplete}/{self.depends.world_size} tasks. Waiting...")
+                time.sleep(2 * 60)
+
+        # 2) Mark this executor as launched
+        self._launched = True
+
+        # 3) Check if all tasks are already completed
+        incomplete_ranks = self.get_incomplete_ranks(range(self.world_size))
+        if not incomplete_ranks:
+            logger.info(f"All {self.world_size} tasks appear to be completed already. Nothing to run.")
+            return
+
+        logger.info(f"Will run pipeline on {len(incomplete_ranks)} incomplete ranks out of {self.world_size} total.")
+
+        # 4) Save executor JSON
+        self.save_executor_as_json()
+
+        # 5) Define resource requirements for this pipeline's tasks
+        remote_options = {
+            "num_cpus": self.num_cpus_per_task,
+            "num_gpus": self.num_gpus_per_task,
+            "memory": self.memory_bytes_per_task,
+        }
+
+        # 6) Dispatch Ray tasks
+        MAX_CONCURRENT_TASKS = self.workers
+        unfinished = []
+
+        for _ in range(min(MAX_CONCURRENT_TASKS, len(incomplete_ranks))):
+            rank_to_submit = incomplete_ranks.pop()
+            unfinished.append(_launch_run_for_rank.options(**remote_options).remote(self, rank_to_submit))
+
+        # 7) Wait for the tasks to finish, merging them as they complete.
+        total_stats = PipelineStats()
+        while unfinished:
+            finished, unfinished = ray.wait(unfinished, num_returns=len(unfinished), timeout=5)
+            try:
+                results = ray.get(finished)
+                for task_result in results:
+                    total_stats += task_result
+            except Exception as e:
+                logger.exception(f"Error processing shard: {e}")
+                raise
+
+            # If we have more shard paths left to process and we haven't hit the max
+            # number of concurrent tasks, add tasks to the unfinished queue.
+            while incomplete_ranks and len(unfinished) < MAX_CONCURRENT_TASKS:
+                rank_to_submit = incomplete_ranks.pop()
+                unfinished.append(_launch_run_for_rank.options(**remote_options).remote(self, rank_to_submit))
+
+        logger.info("All Ray tasks have finished.")
+
+        # 8) Save merged stats
+        with self.logging_dir.open("stats.json", "wt") as statsfile:
+            total_stats.save_to_disk(statsfile)
+
+        logger.success(total_stats.get_repr(f"All {len(incomplete_ranks)} tasks"))
+        return total_stats

--- a/tests/executor/test_ray.py
+++ b/tests/executor/test_ray.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import os
 import shutil
 import tempfile
 import unittest
@@ -8,46 +7,22 @@ import ray
 
 from datatrove.executor.ray import RayPipelineExecutor
 from datatrove.io import get_datafolder
-from datatrove.utils._import_utils import is_boto3_available, is_moto_available, is_s3fs_available
+from datatrove.pipeline.base import PipelineStep
 
-from ..utils import require_boto3, require_moto, require_s3fs
-
-
-if is_boto3_available():
-    import boto3
-
-if is_moto_available():
-    from moto.moto_server.threaded_moto_server import ThreadedMotoServer
-
-if is_s3fs_available():
-    from s3fs import S3FileSystem
 
 port = 5555
 endpoint_uri = f"http://127.0.0.1:{port}/"
 
 
-@require_moto
 class TestRayExecutor(unittest.TestCase):
     def setUp(self):
-        self.server = ThreadedMotoServer(ip_address="127.0.0.1", port=port)
-        self.server.start()
-        os.environ["AWS_SECRET_ACCESS_KEY"] = os.environ["AWS_ACCESS_KEY_ID"] = "foo"
-
         ray.init()
 
         self.tmp_dir = tempfile.mkdtemp()
-
         self.addCleanup(shutil.rmtree, self.tmp_dir)
-        self.addCleanup(self.server.stop)
         self.addCleanup(ray.shutdown)
 
-    @require_boto3
-    @require_s3fs
     def test_executor(self):
-        s3fs = S3FileSystem(client_kwargs={"endpoint_url": endpoint_uri})
-        s3 = boto3.client("s3", region_name="us-east-1", endpoint_url=endpoint_uri)
-        s3.create_bucket(Bucket="test-bucket")
-
         configurations = ((3, 1), (3, 3), (3, -1))
 
         file_list = [
@@ -59,15 +34,17 @@ class TestRayExecutor(unittest.TestCase):
             for x in (f"completions/{rank:05d}", f"logs/task_{rank:05d}.log", f"stats/{rank:05d}.json")
         ]
 
+        class SleepBlock(PipelineStep):
+            def run(self, data, rank=None, world_size=None):
+                for i in range(10):
+                    yield i
+
         for tasks, workers in configurations:
-            for log_dir in (
-                f"{self.tmp_dir}/logs_{tasks}_{workers}",
-                (f"s3://test-bucket/logs_{tasks}_{workers}", s3fs),
-            ):
+            for log_dir in (f"{self.tmp_dir}/logs_{tasks}_{workers}",):
                 log_dir = get_datafolder(log_dir)
 
                 executor = RayPipelineExecutor(
-                    pipeline=[],
+                    pipeline=[SleepBlock()],
                     tasks=tasks,
                     workers=workers,
                     logging_dir=log_dir,

--- a/tests/executor/test_ray.py
+++ b/tests/executor/test_ray.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+import os
+import shutil
+import tempfile
+import unittest
+
+import ray
+
+from datatrove.executor.ray import RayPipelineExecutor
+from datatrove.io import get_datafolder
+from datatrove.utils._import_utils import is_boto3_available, is_moto_available, is_s3fs_available
+
+# Decorators to skip tests if boto3/moto/s3fs unavailable
+from ..utils import require_boto3, require_moto, require_s3fs
+
+
+if is_boto3_available():
+    import boto3
+
+if is_moto_available():
+    from moto.moto_server.threaded_moto_server import ThreadedMotoServer
+
+if is_s3fs_available():
+    from s3fs import S3FileSystem
+
+port = 5555
+endpoint_uri = f"http://127.0.0.1:{port}/"
+
+
+@require_moto
+class TestRayExecutor(unittest.TestCase):
+    def setUp(self):
+        # Start Moto’s local S3 mock server
+        self.server = ThreadedMotoServer(ip_address="127.0.0.1", port=port)
+        self.server.start()
+        os.environ["AWS_SECRET_ACCESS_KEY"] = os.environ["AWS_ACCESS_KEY_ID"] = "foo"
+
+        ray.init()
+
+        # Local temp folder
+        self.tmp_dir = tempfile.mkdtemp()
+
+        # Clean up after test
+        self.addCleanup(shutil.rmtree, self.tmp_dir)
+        self.addCleanup(self.server.stop)
+        self.addCleanup(ray.shutdown)
+
+    @require_boto3
+    @require_s3fs
+    def test_executor(self):
+        """
+        Test the RayPipelineExecutor with different (tasks, workers)-like configs,
+        verifying that it writes the same completion/log/stat files as the Local/Slurm executors.
+        """
+        s3fs = S3FileSystem(client_kwargs={"endpoint_url": endpoint_uri})
+        s3 = boto3.client("s3", region_name="us-east-1", endpoint_url=endpoint_uri)
+        s3.create_bucket(Bucket="test-bucket")
+
+        configurations = ((3, 1), (3, 3), (3, -1))
+
+        file_list = [
+            "executor.json",
+            "stats.json",
+        ] + [
+            x
+            for rank in range(3)
+            for x in (f"completions/{rank:05d}", f"logs/task_{rank:05d}.log", f"stats/{rank:05d}.json")
+        ]
+
+        for tasks, workers in configurations:
+            for log_dir in (
+                f"{self.tmp_dir}/logs_{tasks}_{workers}",
+                (f"s3://test-bucket/logs_{tasks}_{workers}", s3fs),
+            ):
+                log_dir = get_datafolder(log_dir)
+
+                executor = RayPipelineExecutor(
+                    pipeline=[],
+                    tasks=tasks,
+                    workers=workers,
+                    logging_dir=log_dir,
+                )
+                executor.run()
+
+                # Verify the expected files exist
+                for file in file_list:
+                    self.assertTrue(
+                        log_dir.isfile(file),
+                        f"Expected file {file} was not found in {log_dir}",
+                    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -141,3 +141,11 @@ def require_lighteval(test_case):
     except ImportError:
         test_case = unittest.skip("test requires lighteval")(test_case)
     return test_case
+
+
+def require_ray(test_case):
+    try:
+        import ray  # noqa: F401
+    except ImportError:
+        test_case = unittest.skip("test requires ray")(test_case)
+    return test_case

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -141,11 +141,3 @@ def require_lighteval(test_case):
     except ImportError:
         test_case = unittest.skip("test requires lighteval")(test_case)
     return test_case
-
-
-def require_ray(test_case):
-    try:
-        import ray  # noqa: F401
-    except ImportError:
-        test_case = unittest.skip("test requires ray")(test_case)
-    return test_case


### PR DESCRIPTION
Resolves #62 

This PR adds a `RayPipelineExecutor` for running tasks on Ray, as well as a simple smoke test (mirroring the `LocalPipelineExecutor` test). The smoke test sets up and tears down a local Ray cluster to use with the executor.

In addition to the smoke test above, I ran a minhash deduplication job with this `RayPipelineExecutor` and got the same # of output tokens as when I ran the deduplication pipeline with a `LocalPipelineExecutor`. Clearly this isn't a super rigorous test, but maybe there are other tests or workloads you can easily run on your side to verify correctness?

Also, I should add that I'm far from an expert with Ray, so it might be to have someone with more experience take a look at this PR.