### PR TITLE
Fix signatures priority queue initialization in MinhashBuildIndex

### DIFF
--- a/src/datatrove/pipeline/dedup/minhash.py
+++ b/src/datatrove/pipeline/dedup/minhash.py
@@ -671,8 +671,9 @@ class MinhashBuildIndex(PipelineStep):
             for file_i, file in enumerate(self.input_folder.open_files(sig_files, mode="rb"))
         ]
 
-        pq = [next(sig_reader) for sig_reader in sig_readers]
+        pq = [x for x in [next(sig_reader, None) for sig_reader in sig_readers] if x is not None]
         heapq.heapify(pq)
+        logger.info("Finished initializing signatures priority queue.")
 
         # writes all the sigs for the entire bucket, sequentially
         out_f = self.output_folder.open(f"bucket_{bucket:03d}/{self.index_name}.minhash.index", mode="wb")


### PR DESCRIPTION
Fixes #333 . Let me know if this isn't the right fix, I copied it from https://github.com/huggingface/datatrove/blob/main/src/datatrove/pipeline/dedup/minhash.py#L404