### PR TITLE
correct metadata parsing for finemath

### DIFF
--- a/src/datatrove/pipeline/readers/base.py
+++ b/src/datatrove/pipeline/readers/base.py
@@ -58,11 +58,15 @@ class BaseReader(PipelineStep):
         Returns: a dictionary with text, id, media and metadata fields
 
         """
+        metadata = data.pop("metadata", {})
+        if isinstance(metadata, str):
+            metadata = json.loads(metadata)
         return {
             "text": data.pop(self.text_key, ""),
             "id": data.pop(self.id_key, f"{path}/{id_in_file}"),
             "media": data.pop("media", []),
-            "metadata": data.pop("metadata", {}) | data,  # remaining data goes into metadata
+            "metadata": metadata
+            | data,  # remaining data goes into metadata
         }
 
     def get_document_from_dict(self, data: dict, source_file: str, id_in_file: int | str):

--- a/src/datatrove/pipeline/readers/base.py
+++ b/src/datatrove/pipeline/readers/base.py
@@ -70,8 +70,7 @@ class BaseReader(PipelineStep):
             "text": data.pop(self.text_key, ""),
             "id": data.pop(self.id_key, f"{path}/{id_in_file}"),
             "media": data.pop("media", []),
-            "metadata": metadata
-            | data,  # remaining data goes into metadata
+            "metadata": metadata | data,  # remaining data goes into metadata
         }
 
     def get_document_from_dict(self, data: dict, source_file: str, id_in_file: int | str):

--- a/src/datatrove/pipeline/readers/base.py
+++ b/src/datatrove/pipeline/readers/base.py
@@ -60,7 +60,12 @@ class BaseReader(PipelineStep):
         """
         metadata = data.pop("metadata", {})
         if isinstance(metadata, str):
-            metadata = json.loads(metadata)
+            try:
+                metadata = json.loads(metadata)
+            except json.JSONDecodeError:
+                pass
+        if not isinstance(metadata, dict):
+            metadata = {"metadata": metadata}
         return {
             "text": data.pop(self.text_key, ""),
             "id": data.pop(self.id_key, f"{path}/{id_in_file}"),

--- a/src/datatrove/pipeline/readers/base.py
+++ b/src/datatrove/pipeline/readers/base.py
@@ -60,6 +60,7 @@ class BaseReader(PipelineStep):
         """
         metadata = data.pop("metadata", {})
         if isinstance(metadata, str):
+            import json
             try:
                 metadata = json.loads(metadata)
             except json.JSONDecodeError:


### PR DESCRIPTION
When running the following python code

    pipeline_exec = LocalPipelineExecutor(
        pipeline=[
            ParquetReader(
                source_dir,
                batch_size=256,
                doc_progress=True,
                file_progress=True,
                glob_pattern=pattern,
            ),
            JsonlWriter(
                target_dir,
                output_filename=name + ".chunk.${rank}.jsonl",
                compression=None,
            ),
        ],
        tasks=n_tasks,
        logging_dir=log_dir,
    )
    pipeline_exec.run()
    
    On the finemath datasets, an error is raised due to the fact that the metadata are stored as a string and not a dictionary, the patch allows to work around it