### PR TITLE
filters: fix C4BadWordsFilter _get_badwords lang shadowing (fixes #377)

### DIFF
--- a/src/datatrove/pipeline/filters/c4_filters.py
+++ b/src/datatrove/pipeline/filters/c4_filters.py
@@ -252,7 +252,9 @@ class C4BadWordsFilter(BaseFilter):
             # load from file
             with open(local_path, "rt") as f:
                 badwords.update(line.strip() for line in f)
-            for lang, allowlist in _BADWORDS_ALLOWLIST.items():
+            # Do not shadow the method parameter `lang` when iterating allowlist entries
+            for allow_lang, allowlist in _BADWORDS_ALLOWLIST.items():
+                # Only apply allowlist entries irrespective of target lang, as per original logic
                 badwords -= allowlist
 
             words = [re.escape(w) for w in badwords]

--- a/src/datatrove/pipeline/filters/c4_filters.py
+++ b/src/datatrove/pipeline/filters/c4_filters.py
@@ -252,9 +252,7 @@ class C4BadWordsFilter(BaseFilter):
             # load from file
             with open(local_path, "rt") as f:
                 badwords.update(line.strip() for line in f)
-            # Do not shadow the method parameter `lang` when iterating allowlist entries
             for allow_lang, allowlist in _BADWORDS_ALLOWLIST.items():
-                # Only apply allowlist entries irrespective of target lang, as per original logic
                 badwords -= allowlist
 
             words = [re.escape(w) for w in badwords]


### PR DESCRIPTION
Avoid shadowing the  parameter by using a distinct loop variable when iterating .\n\nThis preserves the intended per-language caching in  and prevents subtle issues when switching languages.\n\n- Rename loop var to \n- Logic remains the same (subtract allowlists)\n\nCloses #377.