### PR TITLE
Remove 'file_path' from document metadata when checkpointing

### DIFF
--- a/src/datatrove/pipeline/readers/base.py
+++ b/src/datatrove/pipeline/readers/base.py
@@ -130,6 +130,7 @@ class BaseDiskReader(BaseReader):
         recursive: whether to search files recursively. Ignored if paths_file is provided
         glob_pattern: pattern that all files must match exactly to be included (relative to data_folder). Ignored if paths_file is provided
         shuffle_files: shuffle the files within the returned shard. Mostly used for data viz. purposes, do not use with dedup blocks
+        add_file_path: add the source file path to metadata when missing
     """
 
     type = "📖 - READER"
@@ -149,6 +150,7 @@ class BaseDiskReader(BaseReader):
         recursive: bool = True,
         glob_pattern: str | None = None,
         shuffle_files: bool = False,
+        add_file_path: bool = True,
     ):
         super().__init__(limit, skip, adapter, text_key, id_key, default_metadata)
         self.data_folder = get_datafolder(data_folder)
@@ -158,10 +160,11 @@ class BaseDiskReader(BaseReader):
         self.shuffle_files = shuffle_files
         self.file_progress = file_progress
         self.doc_progress = doc_progress
+        self.add_file_path = add_file_path
 
     def get_document_from_dict(self, data: dict, source_file: str, id_in_file: int):
         document = super().get_document_from_dict(data, source_file, id_in_file)
-        if document:
+        if document and self.add_file_path:
             document.metadata.setdefault("file_path", self.data_folder.resolve_paths(source_file))
         return document
 

--- a/src/datatrove/pipeline/readers/jsonl.py
+++ b/src/datatrove/pipeline/readers/jsonl.py
@@ -28,6 +28,7 @@ class JsonlReader(BaseDiskReader):
         recursive: whether to search files recursively. Ignored if paths_file is provided
         glob_pattern: pattern that all files must match exactly to be included (relative to data_folder). Ignored if paths_file is provided
         shuffle_files: shuffle the files within the returned shard. Mostly used for data viz. purposes, do not use with dedup blocks
+        add_file_path: add the source file path to metadata when missing
     """
 
     name = "🐿 Jsonl"
@@ -49,6 +50,7 @@ class JsonlReader(BaseDiskReader):
         recursive: bool = True,
         glob_pattern: str | None = None,
         shuffle_files: bool = False,
+        add_file_path: bool = True,
     ):
         super().__init__(
             data_folder,
@@ -64,6 +66,7 @@ class JsonlReader(BaseDiskReader):
             recursive,
             glob_pattern,
             shuffle_files,
+            add_file_path,
         )
         self.compression = compression
 


### PR DESCRIPTION
This PR removes a spurious `file_path` from document metadata. 

When resuming inference from checkpoints, documents get an extra `file_path` metadata field that wasn't present in the original data. This causes schema mismatches when loading the final dataset, since some parquet files have the `file_path` column and others don't. 

Error example:

```
CastError: Couldn't cast
text: string
id: string
solution: string
schema_0: list<element: struct<desc: string, points: int64, title: string>>
  child 0, element: struct<desc: string, points: int64, title: string>
      child 0, desc: string
      child 1, points: int64
      child 2, title: string
raw_responses: list<element: string>
  child 0, element: string
dataset: string
rollout_results: list<element: struct<finish_reason: string, text: string, usage: struct<completion_tokens: int64, prompt_tokens: int64, prompt_tokens_details: null, total_tokens: int64>>>
  child 0, element: struct<finish_reason: string, text: string, usage: struct<completion_tokens: int64, prompt_tokens: int64, prompt_tokens_details: null, total_tokens: int64>>
      child 0, finish_reason: string
      child 1, text: string
      child 2, usage: struct<completion_tokens: int64, prompt_tokens: int64, prompt_tokens_details: null, total_tokens: int64>
          child 0, completion_tokens: int64
          child 1, prompt_tokens: int64
          child 2, prompt_tokens_details: null
          child 3, total_tokens: int64
file_path: string
to
{'text': Value('string'), 'id': Value('string'), 'solution': Value('string'), 'schema_0': List({'desc': Value('string'), 'points': Value('int64'), 'title': Value('string')}), 'raw_responses': List(Value('string')), 'dataset': Value('string'), 'rollout_results': List({'finish_reason': Value('string'), 'text': Value('string'), 'usage': {'completion_tokens': Value('int64'), 'prompt_tokens': Value('int64'), 'prompt_tokens_details': Value('null'), 'total_tokens': Value('int64')}})}
because column names don't match
```

This metadata arises because `JsonlReader` extends `BaseDiskReader`, which automatically injects `file_path` into document metadata:

```
# base.py line 163
document.metadata.setdefault("file_path", self.data_folder.resolve_paths(source_file))
```

This means:
* Documents processed fresh → no `file_path`
* Documents restored from checkpoint → `file_path` added

Co-authored with Claude