### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.10"
 
@@ -52,7 +52,7 @@ jobs:
           python -m pytest -sv ./tests/
 
       - name: Tag the release
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           script: |
             github.rest.git.createRef({

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 0
     - name: Secret Scanning
-      uses: trufflesecurity/trufflehog@main
+      uses: trufflesecurity/trufflehog@6bd2d14f7a4bc1e569fa3550efa7ec632a4fa67b  # main
       with:
         extra_args: --only-verified


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `pypi-release.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `pypi-release.yml` | `actions/setup-python` | `v6` | `v6` | `a309ff8b426b…` |
| `pypi-release.yml` | `actions/github-script` | `v8` | `v8` | `ed597411d8f9…` |
| `trufflehog.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `trufflehog.yml` | `trufflesecurity/trufflehog` | `main` | `main` | `6bd2d14f7a4b…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#94

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that pins existing GitHub Actions to immutable SHAs; the main risk is unexpected behavior if the pinned revisions differ from the previously referenced tags/branches.
> 
> **Overview**
> Pins GitHub Actions in `pypi-release.yml` and `trufflehog.yml` to specific commit SHAs (e.g., `actions/checkout`, `actions/setup-python`, `actions/github-script`, `trufflesecurity/trufflehog`) instead of mutable tags/branches.
> 
> This hardens the CI supply chain without changing the workflows’ logic, aside from locking the exact action revisions used at runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9131dc4c2bc56907a20860e195aaa3b0e2c3f4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->