### PR TITLE
Remove transformers>=5.0 uv overrides

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -47,9 +47,7 @@ jobs:
         # uses the version number to fetch the url of the .whl file
         run: |
           python -m pip install uv
-          # Keep the explicit override here: `uv pip install` on the published wheel does not read
-          # this repo's `[tool.uv]` config, and resolution fails on vLLM's current `<5` metadata otherwise.
-          uv pip install --system --overrides uv-overrides.txt datatrove[testing]@$(curl -s https://test.pypi.org/simple/datatrove/ | grep ${{ steps.get_tag_name.outputs.TAG_NAME }}-py3 | sed -nE 's/.*href="([^"]+)".*/\1/p')
+          uv pip install --system datatrove[testing]@$(curl -s https://test.pypi.org/simple/datatrove/ | grep ${{ steps.get_tag_name.outputs.TAG_NAME }}-py3 | sed -nE 's/.*href="([^"]+)".*/\1/p')
           python -m nltk.downloader punkt
           python -m pytest -sv ./tests/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ inference = [
   "typer",
   "pyyaml",
   "pandas",
-  "transformers>=5.0",
 ]
 ray = [
   "ray[default]",
@@ -142,11 +141,6 @@ track_jobs = "datatrove.tools.track_jobs:main"
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
-
-[tool.uv]
-override-dependencies = [
-  "transformers>=5.0",
-]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/uv-overrides.txt
+++ b/uv-overrides.txt
@@ -1,4 +1,0 @@
-# `uv pip install` on the published wheel in the release workflow does not use
-# the repo's `[tool.uv]` override config, so we keep the TestPyPI install path
-# overridden here too.
-transformers>=5.0


### PR DESCRIPTION
## Problem

PR #481 added `transformers>=5.0` overrides in three places to work around vLLM 0.19.0 not yet supporting transformers v5. Now that vLLM 0.19.1 is out with transformers v5 support, these overrides are no longer needed and add unnecessary complexity.

## Solution

Remove all three override locations:

- **`uv-overrides.txt`** — deleted entirely
- **`pyproject.toml`** — removed `transformers>=5.0` from the `[inference]` extra and removed the `[tool.uv] override-dependencies` section
- **`.github/workflows/pypi-release.yml`** — removed `--overrides uv-overrides.txt` flag from the test install step

## Testing

- Dependency resolution should work without overrides now that vLLM 0.19.1 supports transformers v5.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes packaging/CI dependency overrides and a pinned optional dependency; main risk is release/test installs failing if upstream dependency constraints still require the override.
> 
> **Overview**
> Removes the temporary `transformers>=5.0` override workaround now that upstream support has caught up.
> 
> The release workflow no longer installs from TestPyPI with `uv` using `--overrides uv-overrides.txt`, the `uv-overrides.txt` override file is deleted, and `pyproject.toml` drops `transformers>=5.0` from the `inference` extra and removes the `[tool.uv] override-dependencies` section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc442d7bc925ec88d0caae62d94a3710af05fcf7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->