### PR TITLE
Harden shell and archive handling in utility paths

### DIFF
--- a/src/datatrove/pipeline/filters/url_filter.py
+++ b/src/datatrove/pipeline/filters/url_filter.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shutil
 import tarfile
 from typing import Iterable
 
@@ -28,6 +29,31 @@ def parse_list(line, do_normalize=True):
 def get_list(abs_path: str, file_name: str, extra: set, do_normalize: bool = True):
     with open(os.path.join(abs_path, file_name)) as f:
         return parse_list(f, do_normalize).union(extra)
+
+
+def _safe_extract_tar(tar: tarfile.TarFile, destination: str) -> None:
+    destination_path = os.path.abspath(destination)
+    members = tar.getmembers()
+
+    for member in members:
+        target_path = os.path.abspath(os.path.join(destination_path, member.name))
+        if os.path.commonpath([destination_path, target_path]) != destination_path:
+            raise ValueError(f"Refusing to extract tar member outside destination: {member.name}")
+        if not (member.isfile() or member.isdir()):
+            raise ValueError(f"Refusing to extract unsupported tar member type: {member.name}")
+
+    for member in members:
+        target_path = os.path.abspath(os.path.join(destination_path, member.name))
+        if member.isdir():
+            os.makedirs(target_path, exist_ok=True)
+            continue
+
+        os.makedirs(os.path.dirname(target_path), exist_ok=True)
+        source = tar.extractfile(member)
+        if source is None:
+            raise ValueError(f"Unable to extract tar member: {member.name}")
+        with source, open(target_path, "wb") as output:
+            shutil.copyfileobj(source, output)
 
 
 class URLFilter(BaseFilter):
@@ -86,7 +112,7 @@ class URLFilter(BaseFilter):
         def do_extract():
             logger.info("💥 Extracting url filter blacklists...")
             with tarfile.open(os.path.join(ASSETS_PATH, "url_filterblacklistsv0_3_0.tar.gz"), "r:gz") as tar:
-                tar.extractall(download_dir)
+                _safe_extract_tar(tar, download_dir)
             logger.info("💥 Extracted url filter blacklists.")
 
         safely_create_file(file_to_lock, do_extract)

--- a/src/datatrove/utils/jobs.py
+++ b/src/datatrove/utils/jobs.py
@@ -21,9 +21,10 @@ def get_running_slurm_jobs(partition=None):
 
 
 def get_num_slurm_jobs(partition=None):
-    command = (
-        f'squeue{f" -p {partition}" if partition else ""} -u $USER -t pending,running --array --format="%.10t" | wc -l'
-    )
-    output = subprocess.check_output(command, shell=True)
-    num_jobs = int(output.strip())
+    command = ["squeue"]
+    if partition:
+        command.extend(["-p", partition])
+    command.extend(["--me", "-t", "pending,running", "--array", "--format=%.10t"])
+    output = subprocess.check_output(command, text=True)
+    num_jobs = len(output.splitlines())
     return num_jobs

--- a/tests/executor/test_slurm_jobs.py
+++ b/tests/executor/test_slurm_jobs.py
@@ -1,0 +1,25 @@
+from unittest.mock import patch
+
+from datatrove.utils.jobs import get_num_slurm_jobs
+
+
+def test_get_num_slurm_jobs_counts_squeue_lines():
+    with patch("datatrove.utils.jobs.subprocess.check_output", return_value="STATE\nR\nPD\n") as check_output:
+        assert get_num_slurm_jobs() == 3
+
+    check_output.assert_called_once_with(
+        ["squeue", "--me", "-t", "pending,running", "--array", "--format=%.10t"],
+        text=True,
+    )
+
+
+def test_get_num_slurm_jobs_passes_partition_as_single_arg():
+    partition = "gpu; touch /tmp/datatrove-shell-injection"
+
+    with patch("datatrove.utils.jobs.subprocess.check_output", return_value="STATE\n") as check_output:
+        assert get_num_slurm_jobs(partition=partition) == 1
+
+    check_output.assert_called_once_with(
+        ["squeue", "-p", partition, "--me", "-t", "pending,running", "--array", "--format=%.10t"],
+        text=True,
+    )

--- a/tests/pipeline/filters/test_filters.py
+++ b/tests/pipeline/filters/test_filters.py
@@ -1,4 +1,7 @@
+import tarfile
 import unittest
+from io import BytesIO
+from tempfile import TemporaryDirectory
 
 from datatrove.data import Document
 from datatrove.pipeline.filters import (
@@ -13,6 +16,7 @@ from datatrove.pipeline.filters import (
 from datatrove.pipeline.filters.c4_filters import C4ParagraphFilter, C4QualityFilter
 from datatrove.pipeline.filters.fineweb_quality_filter import FineWebQualityFilter
 from datatrove.pipeline.filters.sampler_filter import SamplerFilter
+from datatrove.pipeline.filters.url_filter import _safe_extract_tar
 
 from ...utils import require_fasttext, require_nltk, require_tldextract
 
@@ -133,6 +137,53 @@ class TestFilters(unittest.TestCase):
                 assert url_filter.filter(doc)
             else:
                 self.check_filter(url_filter, doc, result)
+
+    def test_url_filter_tar_extract_rejects_traversal(self):
+        archive = BytesIO()
+        data = b"blocked.example\n"
+        info = tarfile.TarInfo("../domains")
+        info.size = len(data)
+
+        with tarfile.open(fileobj=archive, mode="w:gz") as tar:
+            tar.addfile(info, BytesIO(data))
+
+        archive.seek(0)
+        with TemporaryDirectory() as tmpdir:
+            with tarfile.open(fileobj=archive, mode="r:gz") as tar:
+                with self.assertRaisesRegex(ValueError, "outside destination"):
+                    _safe_extract_tar(tar, tmpdir)
+
+    def test_url_filter_tar_extract_allows_regular_files(self):
+        archive = BytesIO()
+        data = b"blocked.example\n"
+        info = tarfile.TarInfo("domains")
+        info.size = len(data)
+
+        with tarfile.open(fileobj=archive, mode="w:gz") as tar:
+            tar.addfile(info, BytesIO(data))
+
+        archive.seek(0)
+        with TemporaryDirectory() as tmpdir:
+            with tarfile.open(fileobj=archive, mode="r:gz") as tar:
+                _safe_extract_tar(tar, tmpdir)
+
+            with open(f"{tmpdir}/domains", "rb") as extracted:
+                self.assertEqual(extracted.read(), data)
+
+    def test_url_filter_tar_extract_rejects_links(self):
+        archive = BytesIO()
+        info = tarfile.TarInfo("domains-link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "domains"
+
+        with tarfile.open(fileobj=archive, mode="w:gz") as tar:
+            tar.addfile(info)
+
+        archive.seek(0)
+        with TemporaryDirectory() as tmpdir:
+            with tarfile.open(fileobj=archive, mode="r:gz") as tar:
+                with self.assertRaisesRegex(ValueError, "unsupported tar member"):
+                    _safe_extract_tar(tar, tmpdir)
 
 
 class TestSamplerFilter(unittest.TestCase):


### PR DESCRIPTION
## Summary
- build the `squeue` invocation as an argv list instead of a shell command
- pass the optional Slurm partition as a single argument
- keep the previous line-counting behavior for the `squeue` output
- replace URL blacklist `tar.extractall()` with path-checked extraction of regular files/directories only
- add focused regression tests for tar traversal, tar links, and normal file extraction

## Tests
- `PYTHONPATH=src uv run --no-project --with pytest python -m pytest -q tests/executor/test_slurm_jobs.py`
- `python3 -m py_compile src/datatrove/utils/jobs.py tests/executor/test_slurm_jobs.py`
- `uv run --no-project --with ruff ruff check src/datatrove/utils/jobs.py tests/executor/test_slurm_jobs.py`
- `uv run --no-project --with ruff ruff format --check src/datatrove/utils/jobs.py tests/executor/test_slurm_jobs.py`
- `PYTHONPATH=src uv run --no-project --with pytest --with dill --with fsspec --with huggingface-hub --with humanize --with loguru --with multiprocess --with numpy --with tqdm --with regex pytest -q tests/pipeline/filters/test_filters.py -k 'tar_extract'`
- `PYTHONPATH=src uv run --no-project --with ruff ruff check src/datatrove/pipeline/filters/url_filter.py tests/pipeline/filters/test_filters.py`
- `python3 -m py_compile src/datatrove/pipeline/filters/url_filter.py tests/pipeline/filters/test_filters.py`
- `git diff --check`
