### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/src/datatrove/tools/launch_pickled_pipeline.py
+++ b/src/datatrove/tools/launch_pickled_pipeline.py
@@ -1,4 +1,5 @@
 import argparse
+import warnings
 
 import dill
 
@@ -13,6 +14,12 @@ parser.add_argument("path", type=str, help="Path to the pickled file (usually a 
 
 def main():
     args = parser.parse_args()
+    warnings.warn(
+        "WARNING: Loading pickled files can execute arbitrary code. "
+        "Only load files from trusted sources.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
     with open_file(args.path, "rb") as f:
         executor: PipelineExecutor = dill.load(f)
     executor.run()

--- a/src/datatrove/utils/jobs.py
+++ b/src/datatrove/utils/jobs.py
@@ -21,9 +21,9 @@ def get_running_slurm_jobs(partition=None):
 
 
 def get_num_slurm_jobs(partition=None):
-    command = (
-        f'squeue{f" -p {partition}" if partition else ""} -u $USER -t pending,running --array --format="%.10t" | wc -l'
-    )
-    output = subprocess.check_output(command, shell=True)
+    command = ["squeue", "-u", os.environ["USER"], "-t", "pending,running", "--array", "--format=%.10t"]
+    if partition:
+        command.extend(["-p", partition])
+    output = subprocess.check_output(command)
     num_jobs = int(output.strip())
     return num_jobs


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Critical` | **File**: `src/datatrove/tools/launch_pickled_pipeline.py:L15`

The `launch_pickled_pipeline.py` tool uses `dill.load()` to deserialize a pickled pipeline executor from an arbitrary file path provided via command-line argument. Since `dill` (like `pickle`) can execute arbitrary code during deserialization, an attacker who can provide a malicious pickle file could achieve remote code execution. This is a classic deserialization vulnerability with no input validation or sandboxing.

## Solution

Avoid using dill/pickle for loading untrusted data. If this tool must exist, add warnings about only loading trusted files, implement digital signature verification before deserialization, or use a safer serialization format like JSON. Consider restricting file permissions and documenting the security risk prominently.

## Changes

- `src/datatrove/tools/launch_pickled_pipeline.py` (modified)
- `src/datatrove/utils/jobs.py` (modified)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pickle RCE remains possible despite the warning; Slurm job counting may no longer match the prior `wc -l` behavior when multiple jobs exist.
> 
> **Overview**
> Adds a **`RuntimeWarning`** before **`dill.load`** in `launch_pickled_pipeline.py` so operators are explicitly told that unpickling can run arbitrary code and should only use trusted files. Deserialization behavior is unchanged; this is documentation/warning only, not sandboxing or signature checks.
> 
> Refactors **`get_num_slurm_jobs`** in `jobs.py` to invoke **`squeue`** via a **`subprocess` argument list** (and `os.environ["USER"]`) instead of a **`shell=True`** string that interpolated partition and piped through **`wc`**, reducing shell-injection risk when partition or environment values are influenced by callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 917057bcb6bd884fd12ebf375de1d244bede445a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->