### PR TITLE
Require explicit eos_token in MegatronDocumentTokenizer (and fail clearly on an EOS missing from the vocab)

### DIFF
--- a/src/datatrove/pipeline/tokens/megatron_tokenizer.py
+++ b/src/datatrove/pipeline/tokens/megatron_tokenizer.py
@@ -148,7 +148,10 @@ class MegatronDocumentTokenizer(PipelineStepWithTokenizer):
         output_folder (DataFolderLike): the output folder where to save the tokenized documents
         save_filename (str): the filename to use for the final tokenized files (default: None – use the default filename)
         tokenizer_name_or_path (str): the name or path of the tokenizer to use, from the HuggingFace tokenizers library (default: "gpt2")
-        eos_token (str): whether to add the EOS token after each document (default: "<|endoftext|>")
+        eos_token (str): the token appended after each document to mark document boundaries.
+            Required (no default; pass it explicitly). It must match the EOS token your training
+            setup expects, since Megatron uses it to delimit documents (e.g. to reset position ids
+            and attention masks).
         batch_size (int): batch size for tokenization (default: 1000)
         upload_block_size (int | None): the fsspec size of the upload block for remote filesystems (S3)
             You can set this if your s3 uploads are failing because of "Part number must be an integer between 1 and 10000, inclusive".
@@ -163,12 +166,20 @@ class MegatronDocumentTokenizer(PipelineStepWithTokenizer):
         output_folder: DataFolderLike,
         save_filename: str = None,  # If defined, the final output filename will be this
         tokenizer_name_or_path: str = "gpt2",  # Tokenizer to use, from HF or a local
-        eos_token: str = "<|endoftext|>",  # Whether to add the EOS token after each document
+        eos_token: str | None = None,  # required: token appended to mark document boundaries
         batch_size: int = 10000,  # Batch size for tokenization
         upload_block_size: int | None = None,
         # You can set this if your s3 uploads are failing because of "Part
         # number must be an integer between 1 and 10000, inclusive". Example: 20 * 2**20 (20MB)
     ):
+        # eos_token keeps a `None` default (rather than being a required positional/keyword-only
+        # argument) so the calling convention is unchanged; we enforce it explicitly here instead.
+        if eos_token is None:
+            raise ValueError(
+                "eos_token is required: it marks document boundaries in the output and must match "
+                "the EOS token your training setup expects "
+                "(e.g. '<|endoftext|>', '<|end_of_text|>', or '<|im_end|>')."
+            )
         super().__init__(tokenizer_name_or_path, eos_token)
 
         self.output_folder = get_datafolder(output_folder)

--- a/src/datatrove/utils/tokenization.py
+++ b/src/datatrove/utils/tokenization.py
@@ -91,9 +91,15 @@ class PipelineStepWithTokenizer(PipelineStep, ABC):
         if self.post_processor:
             tokenizer.post_processor = self.post_processor
         elif self.eos_token:
+            eos_token_id = tokenizer.token_to_id(self.eos_token)
+            if eos_token_id is None:
+                raise ValueError(
+                    f"eos_token {self.eos_token!r} is not in the vocabulary of tokenizer "
+                    f"{self.tokenizer_name_or_path!r}. Pass an eos_token that exists in this tokenizer."
+                )
             tokenizer.post_processor = TemplateProcessing(
                 single="$A <EOS>",
-                special_tokens=[("<EOS>", tokenizer.token_to_id(self.eos_token))],
+                special_tokens=[("<EOS>", eos_token_id)],
                 pair=None,
             )
         return tokenizer

--- a/tests/pipeline/tokens/test_tokenization.py
+++ b/tests/pipeline/tokens/test_tokenization.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from datatrove.data import Document
 from datatrove.io import DataFolder, get_datafolder
+from datatrove.pipeline.tokens.megatron_tokenizer import MegatronDocumentTokenizer
 from datatrove.pipeline.tokens.merger import DocumentTokenizerMerger
 from datatrove.pipeline.tokens.tokenizer import DocumentTokenizer
 from datatrove.tools.check_dataset import check_dataset, load_doc_ends
@@ -278,3 +279,36 @@ class TestTokenization(unittest.TestCase):
         self.assertNotEqual(merged_windows, token_windows)
         # individual windows were not separated/broken
         self.assertEqual(sorted(merged_windows), sorted(token_windows))
+
+
+@require_tokenizers
+class TestMegatronTokenizerEos(unittest.TestCase):
+    """Regression tests for the MegatronDocumentTokenizer eos_token handling.
+
+    Tier 2: eos_token is required (previously silently defaulted to gpt2's "<|endoftext|>").
+    Tier 1: an eos_token that is not in the tokenizer vocab raises a clear error
+            (previously an opaque TypeError from the tokenizers post-processor).
+    """
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp_dir)
+
+    def test_eos_token_required(self):
+        # Tier 2: omitting eos_token raises immediately instead of silently using gpt2's EOS.
+        with self.assertRaises(ValueError) as ctx:
+            MegatronDocumentTokenizer(self.tmp_dir, tokenizer_name_or_path="gpt2")
+        self.assertIn("eos_token is required", str(ctx.exception))
+
+    def test_eos_token_not_in_vocab(self):
+        # Tier 1: an eos_token absent from the vocab must raise a clear, actionable error.
+        step = MegatronDocumentTokenizer(self.tmp_dir, tokenizer_name_or_path="gpt2", eos_token="<|not_a_real_token|>")
+        with self.assertRaises(ValueError) as ctx:
+            _ = step.tokenizer
+        self.assertIn("not in the vocabulary", str(ctx.exception))
+
+    def test_eos_token_valid(self):
+        # A correct, in-vocab eos_token still works and is appended after each document.
+        step = MegatronDocumentTokenizer(self.tmp_dir, tokenizer_name_or_path="gpt2", eos_token="<|endoftext|>")
+        ids = step.tokenizer.encode("hello world").ids
+        self.assertEqual(ids[-1], 50256)


### PR DESCRIPTION
## Summary

`MegatronDocumentTokenizer` defaults `eos_token` to gpt2's `"<|endoftext|>"` and `PipelineStepWithTokenizer` then applies it to **any** tokenizer with **no validation**. Because `tokenizer_name_or_path` and `eos_token` are independent defaults, the natural action — set the tokenizer, leave the EOS default — silently mismatches them. The EOS here is not cosmetic: it's the document separator Megatron relies on (`GPTDataset` scans the token stream for `tokenizer.eod` to reset position ids / attention masks at document boundaries), so a wrong delimiter silently corrupts training data.

This produces two failure modes, both reproduced below with real modern tokenizers.

## Evidence

Encoding `"hello world"` and inspecting the appended delimiter, using the **default** `eos_token`:

| tokenizer | real EOS | `<\|endoftext\|>` in vocab? | default `eos_token` result |
|---|---|---|---|
| gpt2 / GPT-NeoX-20B | `<\|endoftext\|>` | yes | ✅ correct (by coincidence) |
| Qwen2.5-0.5B (base) | `<\|endoftext\|>` (151643) | yes | ✅ correct (by coincidence) |
| **Llama-3.1-8B** | `<\|end_of_text\|>` | **no** | 💥 `TypeError: argument 'special_tokens': Expected Union[Tuple[str, int], ...]` |
| **Mistral-7B-v0.1** | `</s>` | **no** | 💥 same cryptic `TypeError` |
| **Gemma-2-2B** | `<eos>` | **no** | 💥 same cryptic `TypeError` |
| **Qwen2.5-0.5B-Instruct** | `<\|im_end\|>` (151645) | yes (151643) | 🔇 **silently appends 151643** (`<\|endoftext\|>`), not the tokenizer's EOS |
| **SmolLM2-1.7B-Instruct** | `<\|im_end\|>` (2) | yes (0) | 🔇 **silently appends 0** (`<\|endoftext\|>`), not the tokenizer's EOS |

Root cause, in `utils/tokenization.py`:

```python
special_tokens=[("<EOS>", tokenizer.token_to_id(self.eos_token))]
```

`token_to_id` returns `None` for a missing string (→ the opaque `TypeError` above), and returns a **valid-but-wrong id** when the default string happens to exist as a non-EOS token (→ the silent case).

## Changes

**Tier 1 — `PipelineStepWithTokenizer` (`utils/tokenization.py`):** validate that `eos_token` resolves to a real id; raise a clear `ValueError` (`eos_token '<...>' is not in the vocabulary of tokenizer '<...>'`) instead of letting `None` flow into `TemplateProcessing`. Benefits every tokenizer pipeline step.

**Tier 2 — `MegatronDocumentTokenizer` (`pipeline/tokens/megatron_tokenizer.py`):** `eos_token` is now required in practice — it defaults to `None` and the constructor raises a clear `ValueError` if it's omitted — so it can no longer be silently mismatched to the tokenizer.

### Design note: why `eos_token=None` + an explicit check, rather than a "real" required arg

This keeps `eos_token` as a positional-or-keyword parameter with a `None` default and validates it at runtime ("fake-optional"), instead of making it genuinely required, **specifically to avoid changing the calling convention**. The cleaner-looking alternatives both change how the class can be called:

- **Keyword-only (`*, eos_token: str`)** would also force `batch_size`/`upload_block_size` to be keyword-only (everything after `*`), breaking any positional callers of those.
- **Relocating it to a required positional** (e.g. 2nd arg) would silently change the meaning of existing positional args — e.g. a `MegatronDocumentTokenizer(folder, "myfile")` call intending `save_filename` would pass `"myfile"` as `eos_token`. That's a silent breakage, the worst outcome.

The `None`-default-plus-raise form leaves every existing call signature working while still failing loudly (with a helpful message) when `eos_token` is missing. Happy to switch to the keyword-only form if maintainers prefer the cleaner signature and are OK tightening `batch_size`/`upload_block_size` to keyword-only too.

## Behavior change

Calling convention is unchanged. The behavior change is that **omitting `eos_token` now raises** instead of silently using gpt2's `<|endoftext|>`; callers that relied on the implicit default must pass it explicitly. (Tier 1 alone is non-breaking; Tier 2 is the behavioral change — happy to split if maintainers prefer to land Tier 1 first.)

## Tests

Adds `TestMegatronTokenizerEos` (eos required; eos-not-in-vocab raises a clear error; valid eos still appends correctly). Existing `test_tokenization.py` passes unchanged — those tests already pass `eos_token` explicitly. `ruff format` + `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking for callers that relied on the implicit gpt2 EOS default; changes affect Megatron document delimiters used in training data, though failures are now loud instead of silent corruption.
> 
> **Overview**
> **Megatron tokenization** no longer silently defaults `eos_token` to gpt2’s `<|endoftext|>`. `MegatronDocumentTokenizer` now raises if `eos_token` is omitted, so document-boundary delimiters must be chosen explicitly to match the training stack.
> 
> **Shared tokenizer setup** in `PipelineStepWithTokenizer` checks that `eos_token` exists in the loaded vocabulary before building the post-processor, replacing cryptic `TypeError`s (or wrong-token appends) with a clear `ValueError`.
> 
> Regression tests cover required EOS, invalid EOS strings, and correct EOS appends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 393485d1447add1de9d1634fc5f23063323fd18d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->