### PR TITLE
Fix JsonlWriter crash on pandas.Timestamp metadata

### DIFF
--- a/src/datatrove/pipeline/writers/jsonl.py
+++ b/src/datatrove/pipeline/writers/jsonl.py
@@ -1,8 +1,17 @@
 import base64
-from typing import IO, Callable
+from datetime import date, time
+from typing import IO, Any, Callable
 
 from datatrove.io import DataFolderLike
 from datatrove.pipeline.writers.disk_base import DiskWriter
+
+
+def _json_default(obj: Any) -> str:
+    # orjson serializes datetime objects natively but refuses their subclasses,
+    # such as pandas.Timestamp (produced e.g. by ParquetReader for timestamp columns)
+    if isinstance(obj, (date, time)):
+        return obj.isoformat()
+    raise TypeError(f"Type is not JSON serializable: {type(obj).__name__}")
 
 
 class JsonlWriter(DiskWriter):
@@ -47,4 +56,4 @@ class JsonlWriter(DiskWriter):
         for media in document.get("media", []):
             if media["media_bytes"] is not None:
                 media["media_bytes"] = base64.b64encode(media["media_bytes"]).decode("ascii")
-        file_handler.write(orjson.dumps(document, option=orjson.OPT_APPEND_NEWLINE))
+        file_handler.write(orjson.dumps(document, option=orjson.OPT_APPEND_NEWLINE, default=_json_default))

--- a/tests/pipeline/writers/test_jsonl_writer.py
+++ b/tests/pipeline/writers/test_jsonl_writer.py
@@ -1,0 +1,29 @@
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from datatrove.data import Document
+from datatrove.pipeline.writers.jsonl import JsonlWriter
+
+from ...utils import require_pandas
+
+
+class TestJsonlWriter(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary directory
+        self.tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp_dir)
+
+    @require_pandas
+    def test_write_pandas_timestamp_metadata(self):
+        # pandas.Timestamp is a datetime.datetime subclass, which orjson refuses to serialize natively
+        import pandas as pd
+
+        doc = Document(text="hello", id="0", metadata={"published_date": pd.Timestamp("2021-05-04 22:44:02.776767")})
+        with JsonlWriter(output_folder=self.tmp_dir, compression=None) as w:
+            w.write(doc)
+        with open(os.path.join(self.tmp_dir, "00000.jsonl")) as f:
+            written = json.loads(f.readline())
+        self.assertEqual(written["metadata"]["published_date"], "2021-05-04T22:44:02.776767")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -141,3 +141,11 @@ def require_lighteval(test_case):
     except ImportError:
         test_case = unittest.skip("test requires lighteval")(test_case)
     return test_case
+
+
+def require_pandas(test_case):
+    try:
+        import pandas  # noqa: F401
+    except ImportError:
+        test_case = unittest.skip("test requires pandas")(test_case)
+    return test_case


### PR DESCRIPTION
Fixes #325.

orjson serializes plain `datetime`/`date`/`time` natively but deliberately rejects their subclasses, and `pandas.Timestamp` (what `ParquetReader` yields for timestamp columns) is a `datetime.datetime` subclass — with no `default=` handler, `orjson.dumps` raises. The handler added here emits `isoformat()` for date/time subclasses, matching orjson's native datetime output exactly, while other unserializable types still fail loudly (vs. a blanket `default=str`, which would silently stringify anything — happy to switch to that if preferred).

The new regression test fails on `main` with the exact `TypeError: Type is not JSON serializable: Timestamp` from the issue and passes with this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to JSON serialization in JsonlWriter with explicit errors for unknown types; no auth, security, or data-path changes beyond fixing a metadata edge case.
> 
> **Overview**
> Fixes **`JsonlWriter`** crashing when document metadata contains **`pandas.Timestamp`** (and other `date`/`time` subclasses) by passing a **`default=_json_default`** hook to **`orjson.dumps`**. Subclasses that orjson won’t serialize natively are written as **`isoformat()`** strings, aligned with native datetime output; other non-JSON types still raise **`TypeError`**.
> 
> Adds a regression test that writes a document with timestamp metadata and asserts the ISO string in the JSONL output, plus a **`require_pandas`** skip decorator for optional test deps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a555fecdffc083f890f384cd89e83094bf4b623f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->