### PR TITLE
Fix incomplete stats.json when relaunching a LocalPipelineExecutor job

### DIFF
--- a/src/datatrove/executor/local.py
+++ b/src/datatrove/executor/local.py
@@ -1,3 +1,4 @@
+import json
 import time
 from copy import deepcopy
 from functools import partial
@@ -124,16 +125,15 @@ class LocalPipelineExecutor(PipelineExecutor):
 
             if self.workers == 1:
                 pipeline = self.pipeline
-                stats = []
                 for rank in ranks_to_run:
                     self.pipeline = deepcopy(pipeline)
-                    stats.append(self._launch_run_for_rank(rank, ranks_q))
+                    self._launch_run_for_rank(rank, ranks_q)
             else:
                 completed_counter = mg.Value("i", skipped)
                 completed_lock = mg.Lock()
                 ctx = multiprocess.get_context(self.start_method)
                 with ctx.Pool(self.workers) as pool:
-                    stats = list(
+                    list(
                         pool.imap_unordered(
                             partial(
                                 self._launch_run_for_rank,
@@ -144,8 +144,12 @@ class LocalPipelineExecutor(PipelineExecutor):
                             ranks_to_run,
                         )
                     )
-            # merged stats
-            stats = sum(stats, start=PipelineStats())
+            # merged stats: we merge the persisted per-rank files instead of the values returned by the tasks
+            # themselves, so that tasks already completed in a previous (interrupted) run are also included
+            stats = PipelineStats()
+            for rank in range(self.local_rank_offset, self.local_rank_offset + self.local_tasks):
+                with self.logging_dir.open(f"stats/{rank:05d}.json", "r") as f:
+                    stats += PipelineStats.from_json(json.load(f))
             with self.logging_dir.open("stats.json", "wt") as statsfile:
                 stats.save_to_disk(statsfile)
             logger.success(stats.get_repr(f"All {self.local_tasks} tasks"))

--- a/tests/executor/test_local.py
+++ b/tests/executor/test_local.py
@@ -1,10 +1,13 @@
+import json
 import os
 import shutil
 import tempfile
 import unittest
 
+from datatrove.data import Document
 from datatrove.executor.local import LocalPipelineExecutor
 from datatrove.io import get_datafolder
+from datatrove.pipeline.base import PipelineStep
 from datatrove.utils._import_utils import is_boto3_available, is_moto_available, is_s3fs_available
 
 from ..utils import require_boto3, require_moto, require_s3fs
@@ -30,6 +33,69 @@ if is_moto_available():
 
 if is_s3fs_available():
     from s3fs import S3FileSystem  # noqa: F811
+
+
+class DocGenerator(PipelineStep):
+    """Yields a few documents, tracking a "docs" stat for each one."""
+
+    def __init__(self, docs_per_rank: int):
+        super().__init__()
+        self.docs_per_rank = docs_per_rank
+
+    def run(self, data, rank: int = 0, world_size: int = 1):
+        for doc_i in range(self.docs_per_rank):
+            self.stat_update("docs")
+            yield Document(text=f"document {doc_i}", id=f"{rank}_{doc_i}")
+
+
+class FailFirstTime(PipelineStep):
+    """Raises the first time it is called for fail_rank, succeeds when relaunched."""
+
+    def __init__(self, marker_dir: str, fail_rank: int):
+        super().__init__()
+        self.marker_dir = marker_dir
+        self.fail_rank = fail_rank
+
+    def run(self, data, rank: int = 0, world_size: int = 1):
+        marker_file = os.path.join(self.marker_dir, str(rank))
+        if rank == self.fail_rank and not os.path.isfile(marker_file):
+            open(marker_file, "w").close()
+            raise RuntimeError(f"Simulated failure for {rank=}")
+        yield from data
+
+
+class TestLocalExecutorStats(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp_dir)
+
+    def test_relaunched_job_stats_include_previously_completed_tasks(self):
+        tasks, docs_per_rank, fail_rank = 4, 5, 2
+        logging_dir = os.path.join(self.tmp_dir, "logs")
+        marker_dir = os.path.join(self.tmp_dir, "markers")
+        os.makedirs(marker_dir)
+
+        def get_executor():
+            return LocalPipelineExecutor(
+                pipeline=[DocGenerator(docs_per_rank), FailFirstTime(marker_dir, fail_rank)],
+                tasks=tasks,
+                workers=1,
+                logging_dir=logging_dir,
+            )
+
+        # first run: fail_rank fails, ranks after it never run
+        with self.assertRaises(RuntimeError):
+            get_executor().run()
+        # relaunch: only the incomplete ranks are rerun, but the merged stats should still cover all tasks
+        stats = get_executor().run()
+
+        with get_datafolder(logging_dir).open("stats.json", "rt") as f:
+            saved_stats = json.load(f)
+        for stats_dict in (json.loads(stats.to_json()), saved_stats):
+            docs_stat = stats_dict[0]["stats"]["docs"]
+            # metric stats with a single relevant field are serialized as just their total
+            docs_total = docs_stat["total"] if isinstance(docs_stat, dict) else docs_stat
+            self.assertEqual(docs_total, tasks * docs_per_rank)
 
 
 @require_moto


### PR DESCRIPTION
Fixes #360.

The incomplete `stats.json` after a relaunch is specific to
`LocalPipelineExecutor` (answering the question in the thread): `run()` sums
the `PipelineStats` returned in-memory by the tasks it just ran, and ranks
completed in a previous run are filtered out of `ranks_to_run` (their
`_run_for_rank` returns an empty `PipelineStats`), so their contribution is
dropped — even though each completed rank's stats were correctly persisted to
`stats/{rank:05d}.json`. The ray executor and the `merge_stats` tool already
merge from those persisted files and are not affected.

This PR makes the local executor do the same: after all tasks finish, build
the merged stats from `stats/{rank:05d}.json` for every local rank instead of
summing the in-memory return values. The files are guaranteed to exist at
that point, since a rank is only marked completed after its stats file is
written and the merge only runs once all remaining tasks succeeded.

One side effect to be aware of: for fresh runs too, `stats.json` is now
aggregated per task (e.g. `"docs": {"total": 20, "n": 4, ...}` instead of
`"docs": 20`) — the format the ray executor and `merge_stats` already
produce, so the executors now serialize consistently.

Added a regression test that fails one rank on the first launch, relaunches,
and checks that both the returned stats and `stats.json` cover all tasks
(fails with `AssertionError: 10 != 20` before the fix).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to post-run stats aggregation in the local executor; behavior aligns with existing Ray merge logic and per-rank persistence.
> 
> **Overview**
> **Fixes incomplete `stats.json` when a `LocalPipelineExecutor` job is relaunched** after a partial run (e.g. #360).
> 
> `run()` no longer sums in-memory `PipelineStats` from tasks executed in the current invocation. It now loads and merges `stats/{rank:05d}.json` for every local rank, matching the Ray executor and `merge_stats`. Ranks skipped via `skip_completed` still contribute because their stats were already written when they first completed.
> 
> Fresh runs also get the richer aggregated stat shape in `stats.json` (e.g. per-metric totals with `n`), consistent with Ray.
> 
> A regression test simulates a mid-run failure and relaunch and asserts returned stats and on-disk `stats.json` count all tasks’ work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 396f5db0fdf2305ef0fb106019828314142852d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->