### PR TITLE
Fix extractor sandbox hang when the extract function raises an error

### DIFF
--- a/src/datatrove/pipeline/extractors/base.py
+++ b/src/datatrove/pipeline/extractors/base.py
@@ -91,7 +91,8 @@ class ExtractorSandbox:
         self.child_conn = None
         self.all_processes = []
 
-    def set_oom_score_adj(self, score):
+    @staticmethod
+    def set_oom_score_adj(score):
         if not -1000 <= score <= 1000:
             raise ValueError("Score must be between -1000 and +1000")
         with open("/proc/self/oom_score_adj", "w") as f:
@@ -109,15 +110,23 @@ class ExtractorSandbox:
             self.parent_conn = None
             self.child_conn = None
 
-    def _worker(self, conn, extract_fn):
+    @staticmethod
+    def _worker(conn, extract_fn, warmup_text):
+        # static so that under the "spawn" start method (e.g. macOS) we don't have to pickle the
+        # sandbox itself (self.all_processes may contain non-picklable started Process objects)
         # Ensure this process is killed first
         if platform.system() == "Linux":
-            self.set_oom_score_adj(1000)
+            ExtractorSandbox.set_oom_score_adj(1000)
 
-        if isinstance(self.warmup_text, tuple):
-            extract_fn(*self.warmup_text)  # "warmup"
-        else:
-            extract_fn(self.warmup_text)  # "warmup"
+        try:
+            if isinstance(warmup_text, tuple):
+                extract_fn(*warmup_text)  # "warmup"
+            else:
+                extract_fn(warmup_text)  # "warmup"
+        except Exception:
+            # warmup is best-effort: some extractors raise on the (empty) warmup text but work
+            # fine on real documents. Errors on real documents are reported per document below.
+            pass
         conn.send(None)  # ready
         while True:
             try:
@@ -129,6 +138,14 @@ class ExtractorSandbox:
                 conn.send(result)
             except EOFError:
                 break
+            except Exception as e:
+                # send the exception to the parent instead of dying, so that it can be reported
+                # as a clean_error for this document and the worker can be reused
+                try:
+                    conn.send(e)
+                except Exception:
+                    # exception itself not picklable: send a picklable summary of it
+                    conn.send(Exception(f"{type(e).__name__}: {e}"))
 
     def process_document(self, text, extract_fn):
         self._ensure_process(extract_fn)
@@ -162,18 +179,43 @@ class ExtractorSandbox:
                 self._cleanup_process()
 
             self.parent_conn, self.child_conn = Pipe()
-            self.process = Process(target=self._worker, args=(self.child_conn, extract_fn), daemon=True)
-            self.process.start()
+            process = Process(target=self._worker, args=(self.child_conn, extract_fn, self.warmup_text), daemon=True)
+            try:
+                process.start()
+            except Exception:
+                # never started: drop it so that _cleanup_process doesn't try to terminate() it
+                self.parent_conn.close()
+                self.child_conn.close()
+                self.parent_conn = None
+                self.child_conn = None
+                raise
+            self.process = process
             self.all_processes.append(self.process)
+            # close our copy of the child's end: this way, if the child dies, the pipe reaches
+            # EOF and poll()/recv() report it immediately instead of blocking until the timeout
+            self.child_conn.close()
             # Wait for the "ready" signal from the worker process with a timeout
-            if self.parent_conn.poll(self.timeout):
-                self.parent_conn.recv()  # Receive the None signal
-            else:
-                # Timeout occurred before the worker process signaled it's ready
-                self._cleanup_process()
-                raise TimeoutError(
-                    f"Worker process failed to initialize within {self.timeout} seconds (warmup timeout)."
-                )
+            deadline = time.monotonic() + self.timeout
+            while True:
+                poll_timeout = max(0, min(5, deadline - time.monotonic() + 0.1))
+                if self.parent_conn.poll(poll_timeout):
+                    try:
+                        self.parent_conn.recv()  # Receive the None signal
+                    except EOFError:
+                        # died during warmup (e.g. OOM-killed or a native crash)
+                        self._cleanup_process()
+                        raise EOFError("Worker process died during initialization (warmup)")
+                    return
+                if not self.process.is_alive():
+                    # died during warmup (e.g. OOM-killed or a native crash)
+                    self._cleanup_process()
+                    raise EOFError("Worker process died during initialization (warmup)")
+                if time.monotonic() >= deadline:
+                    # Timeout occurred before the worker process signaled it's ready
+                    self._cleanup_process()
+                    raise TimeoutError(
+                        f"Worker process failed to initialize within {self.timeout} seconds (warmup timeout)."
+                    )
 
     def __enter__(self):
         return self

--- a/tests/pipeline/test_extractor_sandbox.py
+++ b/tests/pipeline/test_extractor_sandbox.py
@@ -1,0 +1,144 @@
+import os
+import time
+import unittest
+
+from datatrove.data import Document
+from datatrove.pipeline.extractors.base import BaseExtractor
+
+
+# extractors must be defined at module level to be picklable under the "spawn" start method (e.g. macOS)
+
+
+class AlwaysFailExtractor(BaseExtractor):
+    """Raises on every input, including the warmup text (https://github.com/huggingface/datatrove/issues/339)."""
+
+    def __init__(self, timeout: float = 10):
+        super().__init__(timeout)
+
+    def extract(self, text: str) -> str:
+        raise ValueError("extraction failed")
+
+
+class MixedExtractor(BaseExtractor):
+    """Fails only on documents containing "FAIL". Returns the worker pid to check worker reuse."""
+
+    def __init__(self, timeout: float = 10):
+        super().__init__(timeout)
+
+    def extract(self, text: str) -> str:
+        if "FAIL" in text:
+            raise ValueError("doc-specific failure")
+        return f"pid:{os.getpid()}"
+
+
+class SlowExtractor(BaseExtractor):
+    """Sleeps longer than the timeout on documents containing "SLOW"."""
+
+    def __init__(self, timeout: float = 1):
+        super().__init__(timeout)
+
+    def extract(self, text: str) -> str:
+        if "SLOW" in text:
+            time.sleep(30)
+        return "fast"
+
+
+class CrashExtractor(BaseExtractor):
+    """Hard-crashes the worker process on every document (simulates a segfault/OOM kill)."""
+
+    def __init__(self, timeout: float = 10):
+        super().__init__(timeout)
+
+    def extract(self, text: str) -> str:
+        if text == "":  # survive warmup
+            return ""
+        os._exit(1)
+
+
+class WarmupCrashExtractor(BaseExtractor):
+    """Hard-crashes the worker process during warmup."""
+
+    def __init__(self, timeout: float = 10):
+        super().__init__(timeout)
+
+    def extract(self, text: str) -> str:
+        os._exit(1)
+
+
+class WarmupOnlyBrokenExtractor(BaseExtractor):
+    """Raises on the empty warmup text but works on real documents."""
+
+    def __init__(self, timeout: float = 10):
+        super().__init__(timeout)
+
+    def extract(self, text: str) -> str:
+        if not text:
+            raise ValueError("cannot handle empty html")
+        return "extracted"
+
+
+def get_docs(*texts):
+    return [Document(text=text, id=str(i)) for i, text in enumerate(texts)]
+
+
+class TestExtractorSandbox(unittest.TestCase):
+    def get_stats(self, extractor):
+        return {key: stat.total for key, stat in extractor.stats.stats.items()}
+
+    def test_extraction_error_is_reported_per_document(self):
+        """An extractor raising on every document (incl. warmup) must not burn the full timeout per document."""
+        extractor = AlwaysFailExtractor(timeout=10)
+        start = time.monotonic()
+        docs = list(extractor.run(iter(get_docs("a", "b", "c"))))
+        elapsed = time.monotonic() - start
+        stats = self.get_stats(extractor)
+        self.assertEqual(len(docs), 0)
+        self.assertEqual(stats.get("clean_error"), 3)
+        self.assertNotIn("timeout", stats)
+        self.assertLess(elapsed, 8)  # before the fix: full 10s timeout per document
+
+    def test_worker_reused_after_extraction_error(self):
+        extractor = MixedExtractor(timeout=10)
+        docs = list(extractor.run(iter(get_docs("a", "FAIL", "b"))))
+        stats = self.get_stats(extractor)
+        self.assertEqual(stats.get("extracted"), 2)
+        self.assertEqual(stats.get("clean_error"), 1)
+        # the error must not kill the worker: both successful documents are processed by the same process
+        self.assertEqual(len({doc.text for doc in docs}), 1)
+
+    def test_timeout_is_still_enforced(self):
+        extractor = SlowExtractor(timeout=1)
+        docs = list(extractor.run(iter(get_docs("a", "SLOW", "b"))))
+        stats = self.get_stats(extractor)
+        self.assertEqual(len(docs), 2)
+        self.assertEqual(stats.get("timeout"), 1)
+        self.assertEqual(stats.get("extracted"), 2)
+
+    def test_worker_crash_detected_quickly(self):
+        extractor = CrashExtractor(timeout=10)
+        start = time.monotonic()
+        docs = list(extractor.run(iter(get_docs("a", "b"))))
+        elapsed = time.monotonic() - start
+        stats = self.get_stats(extractor)
+        self.assertEqual(len(docs), 0)
+        self.assertEqual(stats.get("broken_process"), 2)
+        self.assertLess(elapsed, 8)  # pipe EOF should report the death immediately, not after poll timeouts
+
+    def test_worker_crash_during_warmup(self):
+        extractor = WarmupCrashExtractor(timeout=10)
+        start = time.monotonic()
+        docs = list(extractor.run(iter(get_docs("a", "b"))))
+        elapsed = time.monotonic() - start
+        stats = self.get_stats(extractor)
+        self.assertEqual(len(docs), 0)
+        self.assertEqual(stats.get("broken_process"), 2)
+        self.assertNotIn("timeout", stats)  # death during warmup is not a timeout
+        self.assertLess(elapsed, 8)
+
+    def test_warmup_error_does_not_break_extraction(self):
+        """Extractors that raise on the empty warmup text must still work on real documents."""
+        extractor = WarmupOnlyBrokenExtractor(timeout=10)
+        docs = list(extractor.run(iter(get_docs("a", "b", "c"))))
+        stats = self.get_stats(extractor)
+        self.assertEqual(len(docs), 3)
+        self.assertEqual(stats.get("extracted"), 3)


### PR DESCRIPTION
Fixes #339.

An extractor that raises (as in the issue's warmup traceback) kills the sandbox worker, but the parent doesn't notice the death: it sits in `poll(self.timeout)` and burns the **full timeout for every document**, reporting each one as a generic timeout — the real exception never surfaces. The same applies to per-document errors, since the worker loop only caught `EOFError`, which also made the `isinstance(result, Exception)` branch in `process_document` dead code and forced a respawn per failing document.

There are two more latent crashes on the same path: under the spawn start method the *respawn* fails with `cannot pickle 'weakref.ReferenceType' object` (the bound `self._worker` drags `self.all_processes`, which now holds a started `Process`, into the pickle), and if `start()` raises, `__exit__` crashes with `AttributeError` trying to `terminate()` a never-started process.

This PR makes warmup best-effort (some extractors raise on the empty warmup text but work on real documents), pipes per-document exceptions back to the parent — so they're counted as `clean_error`, logged once, and the worker is reused — and turns `_worker` into a staticmethod so spawn never pickles the sandbox. The parent now also closes its copy of the child pipe end, so a dead worker is detected immediately via EOF instead of after the timeout, and a death during warmup raises `EOFError` (`broken_process`) instead of being misreported as a timeout.

On the issue's scenario (extractor raising on every document, 3 docs, timeout=3) main takes 9s and reports `{'timeout': 3}` under fork (and additionally crashes in `__exit__` under spawn); with this PR it takes 0.1s, reports `{'clean_error': 3}`, and logs the real `ValueError`. Added `tests/pipeline/test_extractor_sandbox.py` covering the error/reuse/timeout/crash/warmup paths (verified under both fork and spawn); existing extractor tests and a Trafilatura end-to-end run through the sandbox still pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multiprocessing lifecycle and error handling on a core extraction path; behavior shifts from timeout to clean_error/broken_process, but timeouts and cleanup paths are covered by new tests.
> 
> **Overview**
> Fixes **extractor sandbox hangs** when `extract` raises: the worker no longer dies silently on per-document errors, so the parent stops burning the full per-document timeout and mis-reporting `timeout` instead of the real failure.
> 
> **`ExtractorSandbox`** now makes warmup **best-effort** (empty warmup can fail without blocking real docs), sends **exceptions back over the pipe** so `BaseExtractor` can count **`clean_error`** and **reuse the worker**, and uses a **static `_worker`** (with `warmup_text` passed in) so **macOS spawn** does not pickle the sandbox/`all_processes`. The parent **closes its child pipe end** and polls warmup readiness like document extraction, so **crashes/EOF** surface quickly as **`broken_process`** / `EOFError` rather than warmup timeouts; failed **`Process.start()`** no longer leaves a half-initialized process for cleanup.
> 
> Adds **`tests/pipeline/test_extractor_sandbox.py`** for always-failing extractors, worker reuse after errors, timeouts, hard crashes, warmup crashes, and warmup-only failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3f5f42420bb7bc2a9a58950f1321f1f181c16a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->