### PR TITLE
refactor(filters): use Counter(x) fast path in GopherRepetitionFilter

### DIFF
--- a/src/datatrove/pipeline/filters/gopher_repetition_filter.py
+++ b/src/datatrove/pipeline/filters/gopher_repetition_filter.py
@@ -47,9 +47,7 @@ def find_duplicates(x: list[str]) -> tuple[int, int]:
 
 
 def find_top_duplicate(x: list[str]) -> int:
-    counter = Counter()
-    for element in x:
-        counter[element] += 1
+    counter = Counter(x)
     top_n_gram = counter.most_common(1)[0]
     return len(top_n_gram[0]) * top_n_gram[1]
 

--- a/tests/pipeline/filters/test_filters.py
+++ b/tests/pipeline/filters/test_filters.py
@@ -1,4 +1,6 @@
+import random
 import unittest
+from collections import Counter
 
 from datatrove.data import Document
 from datatrove.pipeline.filters import (
@@ -12,6 +14,7 @@ from datatrove.pipeline.filters import (
 )
 from datatrove.pipeline.filters.c4_filters import C4ParagraphFilter, C4QualityFilter
 from datatrove.pipeline.filters.fineweb_quality_filter import FineWebQualityFilter
+from datatrove.pipeline.filters.gopher_repetition_filter import find_top_duplicate
 from datatrove.pipeline.filters.sampler_filter import SamplerFilter
 
 from ...utils import require_fasttext, require_nltk, require_tldextract
@@ -39,6 +42,34 @@ TEXT_LF_4 = (
 
 def get_doc(text: str, url: str = "https://example.com") -> Document:
     return Document(text=text, id="0", metadata={"url": url})
+
+
+def _old_find_top_duplicate(x: list[str]) -> int:
+    counter = Counter()
+    for element in x:
+        counter[element] += 1
+    top_n_gram = counter.most_common(1)[0]
+    return len(top_n_gram[0]) * top_n_gram[1]
+
+
+class TestGopherRepetitionHelpers(unittest.TestCase):
+    def test_find_top_duplicate(self):
+        self.assertEqual(find_top_duplicate(["ab", "ab", "ab", "c"]), 6)
+        self.assertEqual(find_top_duplicate(["x"]), 1)
+        # Ties resolve by first-seen order (same as the manual Counter loop).
+        self.assertEqual(find_top_duplicate(["a", "b", "a", "b"]), 2)
+
+    def test_find_top_duplicate_empty_raises(self):
+        with self.assertRaises(IndexError):
+            find_top_duplicate([])
+
+    def test_find_top_duplicate_differential(self):
+        # Counter(x) must match the original manual increment loop on random inputs.
+        random.seed(0)
+        alphabet = ["a", "b", "c", "d", "e"]
+        for _ in range(1000):
+            words = [random.choice(alphabet) for _ in range(random.randint(1, 50))]
+            self.assertEqual(find_top_duplicate(words), _old_find_top_duplicate(words))
 
 
 class TestFilters(unittest.TestCase):


### PR DESCRIPTION
## Summary

`GopherRepetitionFilter` runs on every document in common pipelines (FineWeb, Gopher). Its `find_top_duplicate` helper is called 3x per document (n=2,3,4) and used a manual per-element increment loop:

```python
counter = Counter()
for element in x:
    counter[element] += 1
```

Replaced with `Counter(x)`, which uses CPython's optimized C counting path. This is **behavior-preserving**: both insert keys in first-seen order and `most_common` is a stable sort, so tie-breaking is identical.

## Benchmark (mock data)

Mock documents with a Zipf-ish vocabulary (so common words repeat and the duplicate path is exercised). Timings are the min of 5 runs over 200 docs; CPython 3.13, Apple Silicon. Reproduction script is in the PR thread.

| words/doc | old (loop) | new (`Counter(x)`) | speedup |
|---:|---:|---:|---:|
| 200 | 20.0 us | 7.1 us | **2.82x** |
| 1000 | 99.3 us | 34.2 us | **2.90x** |
| 5000 | 494.5 us | 170.3 us | **2.90x** |

## Tests

Added a `TestGopherRepetitionHelpers` suite in `tests/pipeline/filters/test_filters.py` (the helper operates on a list of strings, so no `nltk`/`spacy` needed):

- `test_find_top_duplicate` — golden values incl. tie-breaking and single-element.
- `test_find_top_duplicate_empty_raises` — documents existing empty-input behavior (the filter guards with `if not n_grams`).
- `test_find_top_duplicate_differential` — asserts `Counter(x)` matches the original manual loop over **1000 randomized inputs** (seeded `random`, no new dependency).

## Test plan

- [x] `pytest tests/pipeline/filters/test_filters.py::TestGopherRepetitionHelpers` — 3 passed
- [x] `ruff check` + `ruff format --check` on changed files — clean
- [x] Differential equivalence (new == old) verified on 1000 randomized inputs
- [ ] Full `make test` in CI (existing `test_gopher_repetition` routes through this helper and requires `spacy`/`nltk`)