### PR TITLE
Preserve chat reasoning outputs in inference results

### DIFF
--- a/src/datatrove/pipeline/inference/run_inference.py
+++ b/src/datatrove/pipeline/inference/run_inference.py
@@ -283,13 +283,21 @@ class InferenceRunner(PipelineStep):
                     self.stat_update("successful_requests", value=1, unit="request")
 
                     # Parse response based on endpoint type
+                    reasoning = ""
                     if self.config.use_chat:
-                        text = choice["message"]["content"]
+                        message = choice["message"]
+                        text = message.get("content") or ""
+                        reasoning = message.get("reasoning") or message.get("reasoning_content") or ""
                     else:
-                        text = choice["text"]
+                        text = choice["text"] or ""
 
                     self.queue_sizes.change_queues({"running_requests": -1})
-                    return InferenceResult(text=text, finish_reason=choice["finish_reason"], usage=usage)
+                    return InferenceResult(
+                        text=text,
+                        finish_reason=choice["finish_reason"],
+                        usage=usage,
+                        reasoning=reasoning,
+                    )
                 except (ConnectionError, OSError, asyncio.TimeoutError) as e:
                     # This means the server is dead likely, let's try again just to be sure
                     logger.warning(f"Client error: {type(e)} {e}")
@@ -349,6 +357,7 @@ class InferenceRunner(PipelineStep):
                     text=cached_result["text"],
                     finish_reason=cached_result["finish_reason"],
                     usage=cached_result["usage"],
+                    reasoning=cached_result.get("reasoning", ""),
                 )
 
         try:
@@ -368,7 +377,12 @@ class InferenceRunner(PipelineStep):
             chunk_index=chunk_index,
             doc_id=doc_id,
             rollout_idx=rollout_idx,
-            result={"text": result.text, "finish_reason": result.finish_reason, "usage": result.usage},
+            result={
+                "text": result.text,
+                "finish_reason": result.finish_reason,
+                "usage": result.usage,
+                "reasoning": result.reasoning,
+            },
             payload_hash=payload_hash,
         )
         return result

--- a/src/datatrove/pipeline/inference/types.py
+++ b/src/datatrove/pipeline/inference/types.py
@@ -11,6 +11,7 @@ class InferenceResult:
 
     Attributes:
         text: Generated text from the model
+        reasoning: Reasoning text from the model, when returned separately from the final answer
         finish_reason: Reason why generation finished
         usage: Token usage statistics from the model
     """
@@ -18,6 +19,7 @@ class InferenceResult:
     text: str
     finish_reason: str
     usage: dict
+    reasoning: str = ""
 
 
 class InferenceError(Exception):

--- a/tests/pipeline/inference/test_inference.py
+++ b/tests/pipeline/inference/test_inference.py
@@ -23,6 +23,18 @@ from datatrove.pipeline.readers.jsonl import JsonlReader
 from datatrove.pipeline.writers import JsonlWriter
 
 
+class StaticResponseServer:
+    """Minimal server stub for testing response parsing."""
+
+    def __init__(self, response):
+        self.response = response
+        self.payloads = []
+
+    async def make_request(self, payload):
+        self.payloads.append(payload.copy())
+        return self.response
+
+
 class ControlledRollout:
     """Rollout function that can be configured to fail at specific document IDs or after a certain count."""
 
@@ -98,6 +110,205 @@ def test_inference_config_validates_server_startup_policy(field_name, value, mes
 
     with pytest.raises(ValueError, match=message):
         InferenceConfig(**config_kwargs)
+
+
+def test_chat_request_preserves_reasoning(tmp_path):
+    async def _run():
+        runner = InferenceRunner(
+            rollout_fn=lambda document, generate: generate({}),
+            config=InferenceConfig(
+                server_type="dummy",
+                model_name_or_path="test-model",
+                max_concurrent_generations=1,
+            ),
+            output_writer=JsonlWriter(str(tmp_path), output_filename="${rank}.jsonl", compression=None),
+        )
+        server = StaticResponseServer(
+            {
+                "choices": [
+                    {
+                        "message": {"content": "final answer", "reasoning": "reasoning trace"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+            }
+        )
+
+        result = await runner._send_request(server, {}, asyncio.Semaphore(1))
+
+        assert result.text == "final answer"
+        assert result.reasoning == "reasoning trace"
+        assert result.finish_reason == "stop"
+        assert result.usage == {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}
+
+    asyncio.run(_run())
+
+
+def test_chat_request_preserves_reasoning_only_response(tmp_path):
+    async def _run():
+        runner = InferenceRunner(
+            rollout_fn=lambda document, generate: generate({}),
+            config=InferenceConfig(
+                server_type="dummy",
+                model_name_or_path="test-model",
+                max_concurrent_generations=1,
+            ),
+            output_writer=JsonlWriter(str(tmp_path), output_filename="${rank}.jsonl", compression=None),
+        )
+        server = StaticResponseServer(
+            {
+                "choices": [
+                    {
+                        "message": {"content": None, "reasoning": "still thinking"},
+                        "finish_reason": "length",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 256, "total_tokens": 257},
+            }
+        )
+
+        result = await runner._send_request(server, {}, asyncio.Semaphore(1))
+
+        assert result.text == ""
+        assert result.reasoning == "still thinking"
+        assert result.finish_reason == "length"
+
+    asyncio.run(_run())
+
+
+def test_chat_request_supports_reasoning_content_alias(tmp_path):
+    async def _run():
+        runner = InferenceRunner(
+            rollout_fn=lambda document, generate: generate({}),
+            config=InferenceConfig(
+                server_type="dummy",
+                model_name_or_path="test-model",
+                max_concurrent_generations=1,
+            ),
+            output_writer=JsonlWriter(str(tmp_path), output_filename="${rank}.jsonl", compression=None),
+        )
+        server = StaticResponseServer(
+            {
+                "choices": [
+                    {
+                        "message": {"content": "", "reasoning_content": "provider reasoning"},
+                        "finish_reason": "length",
+                    }
+                ],
+                "usage": {},
+            }
+        )
+
+        result = await runner._send_request(server, {}, asyncio.Semaphore(1))
+
+        assert result.text == ""
+        assert result.reasoning == "provider reasoning"
+
+    asyncio.run(_run())
+
+
+def test_completion_request_has_empty_reasoning(tmp_path):
+    async def _run():
+        runner = InferenceRunner(
+            rollout_fn=lambda document, generate: generate({}),
+            config=InferenceConfig(
+                server_type="dummy",
+                model_name_or_path="test-model",
+                use_chat=False,
+                max_concurrent_generations=1,
+            ),
+            output_writer=JsonlWriter(str(tmp_path), output_filename="${rank}.jsonl", compression=None),
+        )
+        server = StaticResponseServer(
+            {
+                "choices": [{"text": "completion output", "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1},
+            }
+        )
+
+        result = await runner._send_request(server, {}, asyncio.Semaphore(1))
+
+        assert result.text == "completion output"
+        assert result.reasoning == ""
+
+    asyncio.run(_run())
+
+
+def test_cached_request_defaults_missing_reasoning(tmp_path):
+    async def _run():
+        checkpoints_dir = tmp_path / "checkpoints"
+        payload = {"messages": [{"role": "user", "content": "hello"}]}
+
+        seed_runner = InferenceRunner(
+            rollout_fn=lambda document, generate: generate({}),
+            config=InferenceConfig(
+                server_type="dummy",
+                model_name_or_path="test-model",
+                max_concurrent_generations=1,
+            ),
+            output_writer=JsonlWriter(
+                str(tmp_path / "seed"),
+                output_filename="${rank}_${chunk_index}.jsonl",
+                compression=None,
+            ),
+            checkpoints_local_dir=str(checkpoints_dir),
+        )
+        await seed_runner.request_cache.initialize(rank=0)
+        payload_hash = seed_runner.request_cache.prepare_payload(payload)
+        await seed_runner.request_cache.store_result(
+            chunk_index=0,
+            doc_id="doc-1",
+            rollout_idx=0,
+            result={"text": "cached answer", "finish_reason": "stop", "usage": {"prompt_tokens": 1}},
+            payload_hash=payload_hash,
+        )
+        await seed_runner.request_cache.flush()
+        await seed_runner.request_cache.close()
+
+        runner = InferenceRunner(
+            rollout_fn=lambda document, generate: generate({}),
+            config=InferenceConfig(
+                server_type="dummy",
+                model_name_or_path="test-model",
+                max_concurrent_generations=1,
+            ),
+            output_writer=JsonlWriter(
+                str(tmp_path / "resume"),
+                output_filename="${rank}_${chunk_index}.jsonl",
+                compression=None,
+            ),
+            checkpoints_local_dir=str(checkpoints_dir),
+        )
+        await runner.request_cache.initialize(rank=0)
+        server = StaticResponseServer(
+            {
+                "choices": [
+                    {
+                        "message": {"content": "should not be called"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {},
+            }
+        )
+
+        result = await runner._cached_request(
+            payload,
+            asyncio.Semaphore(1),
+            server,
+            doc_id="doc-1",
+            rollout_idx=0,
+            chunk_index=0,
+        )
+
+        assert result.text == "cached answer"
+        assert result.reasoning == ""
+        assert server.payloads == []
+
+        await runner.request_cache.close(delete_file=True)
+
+    asyncio.run(_run())
 
 
 def test_multiple_rollouts_collect_results(tmp_path):

--- a/tests/pipeline/text/test_request_cache.py
+++ b/tests/pipeline/text/test_request_cache.py
@@ -9,7 +9,12 @@ def test_request_cache_store_and_fetch(tmp_path):
         await cache.initialize(rank=0)
 
         payload = {"prompt": "hello"}
-        result = {"text": "world", "finish_reason": "stop", "usage": {"prompt_tokens": 1}}
+        result = {
+            "text": "world",
+            "finish_reason": "stop",
+            "usage": {"prompt_tokens": 1},
+            "reasoning": "scratchpad",
+        }
 
         # no cached entry for doc-1 initially
         payload_hash = cache.prepare_payload(payload)


### PR DESCRIPTION
## Summary
- add an optional reasoning field to InferenceResult
- parse vLLM/OpenAI-compatible chat reasoning from message.reasoning or message.reasoning_content
- preserve reasoning through request-cache storage and restore old cache rows with reasoning=''

## Tests
- env PYTHONPATH=/fsx/edward/work/datatrove/src /fsx/edward/work/dataforge/.venv/bin/python -m pytest tests/pipeline/test_inference.py::test_chat_request_preserves_reasoning tests/pipeline/test_inference.py::test_chat_request_preserves_reasoning_only_response tests/pipeline/test_inference.py::test_chat_request_supports_reasoning_content_alias tests/pipeline/test_inference.py::test_completion_request_has_empty_reasoning tests/pipeline/test_inference.py::test_cached_request_defaults_missing_reasoning tests/pipeline/test_request_cache.py::test_request_cache_store_and_fetch
- env PYTHONPATH=/fsx/edward/work/datatrove/src DATATROVE_NODE_RANK=0 /fsx/edward/work/dataforge/.venv/bin/python -m pytest tests/pipeline/test_inference.py tests/pipeline/test_request_cache.py
- env PYTHONPATH=/fsx/edward/work/datatrove/src /fsx/edward/work/dataforge/.venv/bin/python -m ruff check src/datatrove/pipeline/inference/run_inference.py src/datatrove/pipeline/inference/types.py tests/pipeline/test_inference.py tests/pipeline/test_request_cache.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive inference result shape and response parsing; default empty reasoning keeps existing rollouts and old cache entries compatible.
> 
> **Overview**
> Adds an optional **`reasoning`** field on **`InferenceResult`** so models that return a separate chain-of-thought from the final answer can expose both.
> 
> **Chat parsing** in **`_send_request`** now reads **`message.content`** (with **`None`/missing → `""`**) and **`reasoning`** from **`message.reasoning`** or **`message.reasoning_content`**. Completion mode still only fills **`text`**; **`reasoning`** stays empty.
> 
> **Request cache** stores and restores **`reasoning`** with each cached result; cache hits without that key default **`reasoning`** to **`""`** for backward compatibility.
> 
> Tests cover chat/completion parsing, the **`reasoning_content`** alias, and cached replay without **`reasoning`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbbf60eb229397d7b2d37c94d998a446f6e0d254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->