### PR TITLE
Add JobsPipelineExecutor: run datatrove pipelines on HF Jobs (experimental)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Local, remote and other file systems are supported through [fsspec](https://file
   * [LocalPipelineExecutor](#localpipelineexecutor)
   * [SlurmPipelineExecutor](#slurmpipelineexecutor)
   * [RayPipelineExecutor](#raypipelineexecutor)
+  * [JobsPipelineExecutor](#jobspipelineexecutor)
 - [Logging](#logging)
 - [DataFolder / paths](#datafolder--paths)
 - [Practical guides](#practical-guides)
@@ -273,6 +274,9 @@ executor = RayPipelineExecutor(
 executor.run()
 ```
 </details>
+
+### JobsPipelineExecutor
+**Experimental — may change or be removed without notice.** Runs pipelines on [Hugging Face Jobs](https://huggingface.co/docs/huggingface_hub/en/guides/jobs): same coordination model as Slurm, but each block of tasks runs in a cloud Job. See the [`JobsPipelineExecutor` docstring](src/datatrove/executor/jobs.py) and the `*_jobs.py` [examples](examples) for usage.
 
 ## Logging
 For a pipeline with `logging_dir` **mylogspath/exp1**, the following folder structure would be created:

--- a/examples/filter_hf_dataset_jobs.py
+++ b/examples/filter_hf_dataset_jobs.py
@@ -15,6 +15,14 @@ Differences from the Slurm version (see comments inline):
   env_command / conda / venv to pre-activate.
 - Slurm's partition / qos / cpus_per_task / mem_per_cpu_gb / time collapse into one `flavor` (+ `timeout`).
 - `workers` caps concurrent Jobs (Slurm's `%workers`).
+
+Two gotchas the fresh-env model introduces:
+- `dependencies` must include every datatrove *extra* your steps need — not just the obvious ones.
+  Even `LambdaFilter` requires `datatrove[processing]`, because importing `datatrove.pipeline.filters`
+  eagerly imports `regex`. A missing extra fails the Job at unpickle time.
+- Point `logging_dir` at a DIFFERENT repo than your output data. If logs (`executor.json`, `stats.json`)
+  and your output parquet share one HF dataset repo, the Hub dataset viewer tries to cast them into one
+  table and errors.
 """
 
 import argparse

--- a/examples/filter_hf_dataset_jobs.py
+++ b/examples/filter_hf_dataset_jobs.py
@@ -1,5 +1,5 @@
 """
-Note: `JobsPipelineExecutor` is experimental and its API may change in future releases.
+Note: `JobsPipelineExecutor` is experimental and may change, break, or be removed in future releases.
 
 This file contains code to:
 1 - Load a parquet-format Hugging Face dataset from the hub.

--- a/examples/filter_hf_dataset_jobs.py
+++ b/examples/filter_hf_dataset_jobs.py
@@ -47,9 +47,10 @@ REMOTE_LOGS_PATH = "hf://datasets/my_org/my-filter-logs"
 # datatrove + every extra/dep your pipeline steps need, installed into each Job's uv env.
 # NB: even LambdaFilter needs the `processing` extra — importing datatrove.pipeline.filters
 # eagerly pulls in modules that require `regex`. Match the extras to the steps you use.
-# Until JobsPipelineExecutor is released, install datatrove from your branch, e.g.:
-#   "datatrove[io,processing] @ git+https://github.com/<user>/datatrove@<branch>"
-DEPENDENCIES = ["datatrove[io,processing]"]
+# Installed from git because no released datatrove ships JobsPipelineExecutor yet — with a
+# released version the Job dies at unpickle time (the class doesn't exist in the Job's env).
+# TODO: switch to "datatrove[io,processing]" once a release includes the Jobs executor.
+DEPENDENCIES = ["datatrove[io,processing] @ git+https://github.com/huggingface/datatrove"]
 
 if __name__ == "__main__":
     args = parser.parse_args()

--- a/examples/filter_hf_dataset_jobs.py
+++ b/examples/filter_hf_dataset_jobs.py
@@ -1,4 +1,6 @@
 """
+Note: `JobsPipelineExecutor` is experimental and its API may change in future releases.
+
 This file contains code to:
 1 - Load a parquet-format Hugging Face dataset from the hub.
 2 - Filter the dataset (to include only entries that contain the word 'hugging' in the text column).

--- a/examples/filter_hf_dataset_jobs.py
+++ b/examples/filter_hf_dataset_jobs.py
@@ -1,0 +1,71 @@
+"""
+This file contains code to:
+1 - Load a parquet-format Hugging Face dataset from the hub.
+2 - Filter the dataset (to include only entries that contain the word 'hugging' in the text column).
+3 - Push the filtered dataset back to the hub.
+
+...running on Hugging Face Jobs. It is the `JobsPipelineExecutor` twin of `filter_hf_dataset.py`
+(which uses Slurm) — the pipeline is identical; only the executor changes. Your machine just
+orchestrates: the filtering runs across a pool of Jobs that coordinate through a shared, *remote*
+`logging_dir`.
+
+Differences from the Slurm version (see comments inline):
+- `logging_dir` MUST be remote (hf:// or s3://) — the launcher and the Jobs are different machines.
+- `dependencies` are declared explicitly (each Job builds a fresh `uv` env); there is no
+  env_command / conda / venv to pre-activate.
+- Slurm's partition / qos / cpus_per_task / mem_per_cpu_gb / time collapse into one `flavor` (+ `timeout`).
+- `workers` caps concurrent Jobs (Slurm's `%workers`).
+"""
+
+import argparse
+
+
+parser = argparse.ArgumentParser("Filter an HF dataset on HF Jobs and push the result to the hub")
+
+parser.add_argument("input_dataset", type=str, help="HF dataset to filter")
+parser.add_argument("output_name", type=str, help="Name of the output dataset")
+parser.add_argument("--n_tasks", type=int, help="number of tasks", default=100)
+parser.add_argument("--workers", type=int, help="max concurrent Jobs (-1 = all at once)", default=20)
+parser.add_argument("--flavor", type=str, help="HF Jobs hardware flavor", default="cpu-basic")
+parser.add_argument("--text_key", type=str, help="text column", default="text")
+
+ORG_NAME = "my_org"
+# Jobs coordinate ONLY through a shared REMOTE logging_dir (hf:// or s3://), never a local path.
+# Keep this OUT of the output dataset repo — otherwise the Hub dataset viewer tries to cast
+# executor.json / stats.json into the same table as your parquet and errors.
+REMOTE_LOGS_PATH = "hf://datasets/my_org/my-filter-logs"
+# datatrove + every extra/dep your pipeline steps need, installed into each Job's uv env.
+# NB: even LambdaFilter needs the `processing` extra — importing datatrove.pipeline.filters
+# eagerly pulls in modules that require `regex`. Match the extras to the steps you use.
+# Until JobsPipelineExecutor is released, install datatrove from your branch, e.g.:
+#   "datatrove[io,processing] @ git+https://github.com/<user>/datatrove@<branch>"
+DEPENDENCIES = ["datatrove[io,processing]"]
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    from datatrove.executor import JobsPipelineExecutor
+    from datatrove.pipeline.filters import LambdaFilter
+    from datatrove.pipeline.readers import ParquetReader
+    from datatrove.pipeline.writers.huggingface import HuggingFaceDatasetWriter
+
+    dist_executor = JobsPipelineExecutor(
+        job_name=f"filter-{args.output_name}",
+        pipeline=[
+            ParquetReader(args.input_dataset, glob_pattern="**/*.parquet", text_key=args.text_key),
+            LambdaFilter(lambda doc: "hugging" in doc.text),  # add your custom filter here
+            HuggingFaceDatasetWriter(
+                dataset=f"{ORG_NAME}/{args.output_name}",
+                private=True,
+                local_working_dir=f"/tmp/{args.output_name}",  # Job-local scratch (ephemeral); cleaned up
+                output_filename="data/${rank}.parquet",
+                cleanup=True,
+            ),
+        ],
+        tasks=args.n_tasks,
+        workers=args.workers,  # concurrency cap — the analog of Slurm's `--array 0-M%workers`
+        logging_dir=f"{REMOTE_LOGS_PATH}/{args.output_name}",  # remote (hf://) — shared by launcher + Jobs
+        flavor=args.flavor,  # one hardware knob instead of partition/qos/cpus_per_task/mem_per_cpu_gb
+        dependencies=DEPENDENCIES,  # each Job builds a fresh uv env — declare deps explicitly
+        timeout="2h",
+    )
+    dist_executor.run()

--- a/examples/minhash_deduplication_jobs.py
+++ b/examples/minhash_deduplication_jobs.py
@@ -1,0 +1,132 @@
+"""
+MinHash deduplication on Hugging Face Jobs — the `JobsPipelineExecutor` twin of
+`minhash_deduplication.py` (Slurm). The 4-stage pipeline is identical; only the executors change.
+
+  stage1 signatures -> stage2 buckets (depends=1) -> stage3 cluster (depends=2) -> stage4 filter (depends=3)
+
+Notes specific to running this multi-stage dedup on Jobs (see `filter_hf_dataset_jobs.py` for the
+general Slurm->Jobs comparison):
+- `MINHASH_BASE_PATH` and the logs must be a shared REMOTE path (hf:// or s3://) that all four stages
+  read/write. HF S3-compatible buckets are a good fit and reduce read-after-write races between stages.
+- `dependencies` = `datatrove[io,processing]` PLUS `spacy`: the signature stage's English word tokenizer
+  is `spacy.blank("en")` (no model download), and `spacy` only ships in the heavy `multilingual` extra,
+  so add the bare package rather than that whole extra.
+- `max_retries >= 1` matters here: `hf://` has read-after-write lag, so a downstream stage can 404 on a
+  file the previous stage just wrote; a retry succeeds once it propagates. (Not needed on a strongly
+  consistent store.)
+- stage 1 and stage 4 MUST use the same input reader and the same task count (unchanged from Slurm).
+- Set `workers=N` on the stages to cap concurrent Jobs (the analog of Slurm's `%workers`).
+"""
+
+from datatrove.executor import JobsPipelineExecutor
+from datatrove.pipeline.dedup import MinhashDedupSignature
+from datatrove.pipeline.dedup.minhash import (
+    MinhashConfig,
+    MinhashDedupBuckets,
+    MinhashDedupCluster,
+    MinhashDedupFilter,
+)
+from datatrove.pipeline.readers import HuggingFaceDatasetReader
+from datatrove.pipeline.tokens import TokensCounter
+from datatrove.pipeline.writers.jsonl import JsonlWriter
+from datatrove.utils.hashing import HashConfig
+from datatrove.utils.typeshelper import Languages
+
+
+# you can also change ngrams or the number of buckets and their size here
+minhash_config = MinhashConfig(
+    hash_config=HashConfig(precision=64),
+    num_buckets=14,
+    hashes_per_bucket=8,
+)  # better precision -> fewer false positives (collisions)
+
+# a shared REMOTE base path all four stages use (hf:// or s3://) — never a local path
+MINHASH_BASE_PATH = "hf://datasets/my_org/my-minhash"
+LOGS_FOLDER = "hf://datasets/my_org/my-minhash-logs"
+
+# datatrove + processing (nltk/xxhash/regex/tokenizers) + bare spacy (English word tokenizer).
+# Until JobsPipelineExecutor is released, install datatrove from your branch, e.g.:
+#   "datatrove[io,processing] @ git+https://github.com/<user>/datatrove@<branch>"
+DEPENDENCIES = ["datatrove[io,processing]", "spacy"]
+
+TOTAL_TASKS = 50
+
+# this is the original data that we want to deduplicate — stage 1 and stage 4 must use the SAME reader
+INPUT_READER = HuggingFaceDatasetReader("stanfordnlp/imdb", dataset_options={"split": "train"}, text_key="text")
+
+# shared executor config for every stage
+common = {
+    "flavor": "cpu-basic",
+    "dependencies": DEPENDENCIES,
+    "timeout": "2h",
+    "max_retries": 2,  # tolerate transient hf:// read-after-write 404s between stages
+}
+
+# stage 1 computes minhash signatures for each task (each task gets a set of files)
+stage1 = JobsPipelineExecutor(
+    job_name="mh1",
+    pipeline=[
+        INPUT_READER,
+        MinhashDedupSignature(
+            output_folder=f"{MINHASH_BASE_PATH}/signatures", config=minhash_config, language=Languages.english
+        ),
+    ],
+    tasks=TOTAL_TASKS,
+    logging_dir=f"{LOGS_FOLDER}/signatures",
+    **common,
+)
+
+# stage 2 finds matches between signatures in each bucket
+stage2 = JobsPipelineExecutor(
+    job_name="mh2",
+    pipeline=[
+        MinhashDedupBuckets(
+            input_folder=f"{MINHASH_BASE_PATH}/signatures",
+            output_folder=f"{MINHASH_BASE_PATH}/buckets",
+            config=minhash_config,
+        ),
+    ],
+    tasks=minhash_config.num_buckets,
+    logging_dir=f"{LOGS_FOLDER}/buckets",
+    depends=stage1,
+    **common,
+)
+
+# stage 3 creates clusters of duplicates using the results from all buckets
+stage3 = JobsPipelineExecutor(
+    job_name="mh3",
+    pipeline=[
+        MinhashDedupCluster(
+            input_folder=f"{MINHASH_BASE_PATH}/buckets",
+            output_folder=f"{MINHASH_BASE_PATH}/remove_ids",
+            config=minhash_config,
+        ),
+    ],
+    tasks=1,
+    logging_dir=f"{LOGS_FOLDER}/clusters",
+    depends=stage2,
+    **common,
+)
+
+# stage 4 reads the original input and removes all but 1 sample per duplicate cluster
+# the data must match exactly stage 1, so number of tasks and the input source must be the same
+stage4 = JobsPipelineExecutor(
+    job_name="mh4",
+    pipeline=[
+        INPUT_READER,
+        TokensCounter(),  # nice way to see how many tokens we had before and after deduplication
+        MinhashDedupFilter(
+            input_folder=f"{MINHASH_BASE_PATH}/remove_ids",
+            exclusion_writer=JsonlWriter(f"{MINHASH_BASE_PATH}/removed"),
+        ),
+        JsonlWriter(output_folder=f"{MINHASH_BASE_PATH}/deduplicated_output"),
+    ],
+    tasks=TOTAL_TASKS,
+    logging_dir=f"{LOGS_FOLDER}/filter",
+    depends=stage3,
+    **common,
+)
+
+
+if __name__ == "__main__":
+    stage4.run()

--- a/examples/minhash_deduplication_jobs.py
+++ b/examples/minhash_deduplication_jobs.py
@@ -2,7 +2,7 @@
 MinHash deduplication on Hugging Face Jobs — the `JobsPipelineExecutor` twin of
 `minhash_deduplication.py` (Slurm). The 4-stage pipeline is identical; only the executors change.
 
-Note: `JobsPipelineExecutor` is experimental and its API may change in future releases.
+Note: `JobsPipelineExecutor` is experimental and may change, break, or be removed in future releases.
 
   stage1 signatures -> stage2 buckets (depends=1) -> stage3 cluster (depends=2) -> stage4 filter (depends=3)
 

--- a/examples/minhash_deduplication_jobs.py
+++ b/examples/minhash_deduplication_jobs.py
@@ -93,6 +93,11 @@ stage2 = JobsPipelineExecutor(
             input_folder=f"{MINHASH_BASE_PATH}/signatures",
             output_folder=f"{MINHASH_BASE_PATH}/buckets",
             config=minhash_config,
+            # IMPORTANT on remote storage: the default (5) also sets the fsspec block_size to 5 lines
+            # (~340 bytes), i.e. one HTTP range request per couple of reads — measured ~40x slower on
+            # Jobs (65 min -> 99 s for this stage). -1 reads each signature file in a single request;
+            # it buffers whole files in RAM, so at very high task counts stage to local disk instead.
+            lines_to_buffer=-1,
         ),
     ],
     tasks=minhash_config.num_buckets,

--- a/examples/minhash_deduplication_jobs.py
+++ b/examples/minhash_deduplication_jobs.py
@@ -2,6 +2,8 @@
 MinHash deduplication on Hugging Face Jobs — the `JobsPipelineExecutor` twin of
 `minhash_deduplication.py` (Slurm). The 4-stage pipeline is identical; only the executors change.
 
+Note: `JobsPipelineExecutor` is experimental and its API may change in future releases.
+
   stage1 signatures -> stage2 buckets (depends=1) -> stage3 cluster (depends=2) -> stage4 filter (depends=3)
 
 Notes specific to running this multi-stage dedup on Jobs (see `filter_hf_dataset_jobs.py` for the

--- a/examples/minhash_deduplication_jobs.py
+++ b/examples/minhash_deduplication_jobs.py
@@ -10,6 +10,10 @@ Notes specific to running this multi-stage dedup on Jobs (see `filter_hf_dataset
 general Slurm->Jobs comparison):
 - `MINHASH_BASE_PATH` and the logs must be a shared REMOTE path (hf:// or s3://) that all four stages
   read/write. HF S3-compatible buckets are a good fit and reduce read-after-write races between stages.
+- At higher fan-out, many Jobs committing small files to a single hf:// dataset repo can hit per-repo
+  commit rate limits (429 "maximum time in concurrency queue reached") in the signature stage. If you
+  see those: use an s3:// bucket for `MINHASH_BASE_PATH`, lower `workers`, and/or rerun to resume —
+  only the failed ranks are relaunched.
 - `dependencies` = `datatrove[io,processing]` PLUS `spacy`: the signature stage's English word tokenizer
   is `spacy.blank("en")` (no model download), and `spacy` only ships in the heavy `multilingual` extra,
   so add the bare package rather than that whole extra.

--- a/examples/minhash_deduplication_jobs.py
+++ b/examples/minhash_deduplication_jobs.py
@@ -8,11 +8,14 @@ Note: `JobsPipelineExecutor` is experimental and may change, break, or be remove
 
 Notes specific to running this multi-stage dedup on Jobs (see `filter_hf_dataset_jobs.py` for the
 general Slurm->Jobs comparison):
-- `MINHASH_BASE_PATH` and the logs must be a shared REMOTE path (hf:// or s3://) that all four stages
-  read/write. HF S3-compatible buckets are a good fit and reduce read-after-write races between stages.
-- At higher fan-out, many Jobs committing small files to a single hf:// dataset repo can hit per-repo
-  commit rate limits (429 "maximum time in concurrency queue reached") in the signature stage. If you
-  see those: use an s3:// bucket for `MINHASH_BASE_PATH`, lower `workers`, and/or rerun to resume —
+- `MINHASH_BASE_PATH` and the logs must be a shared REMOTE path that all four stages read/write.
+  HF Storage Buckets (`hf://buckets/<user>/<bucket>/...`, needs huggingface_hub>=1.6.0) are the best
+  fit: the same fsspec code path as `hf://datasets/...`, but object-storage semantics — no per-repo
+  commit queue and no read-after-write lag between stages.
+- At higher fan-out, many Jobs committing small files to a single hf:// *dataset repo* can hit per-repo
+  commit rate limits (429 "maximum time in concurrency queue reached") in the signature stage — a
+  signature stage that failed 6/24 ranks on a dataset repo at `workers=8` passed 24/24 on a bucket with
+  identical settings. If you must stay on a dataset repo: lower `workers`, and/or rerun to resume —
   only the failed ranks are relaunched.
 - `dependencies` = `datatrove[io,processing]` PLUS `spacy`: the signature stage's English word tokenizer
   is `spacy.blank("en")` (no model download), and `spacy` only ships in the heavy `multilingual` extra,

--- a/examples/minhash_deduplication_jobs.py
+++ b/examples/minhash_deduplication_jobs.py
@@ -17,6 +17,15 @@ general Slurm->Jobs comparison):
   signature stage that failed 6/24 ranks on a dataset repo at `workers=8` passed 24/24 on a bucket with
   identical settings. If you must stay on a dataset repo: lower `workers`, and/or rerun to resume —
   only the failed ranks are relaunched.
+- stage 2 sets `lines_to_buffer=-1` on `MinhashDedupBuckets`, and on remote storage you should too
+  (at this kind of scale). The default (5) is a RAM bound tuned for local filesystems: stage 2 holds
+  EVERY stage-1 signature file open at once for its merge, and the value also sets the fsspec
+  `block_size` (5 lines ≈ 340 bytes) — so over hf:// each couple of reads becomes its own HTTP range
+  request, ~500 requests per signature file (measured: this stage went 65 min → 99 s after switching
+  to -1). -1 instead reads each file in a single request but buffers whole files in RAM: budget
+  `num_stage1_tasks × sig_file_size` (here 24 × ~340 KB ≈ 8 MB — trivial). At thousands of stage-1
+  tasks, keep a bounded `lines_to_buffer` and stage the bucket's signature files to the Job's local
+  ephemeral disk first instead.
 - `dependencies` = `datatrove[io,processing]` PLUS `spacy`: the signature stage's English word tokenizer
   is `spacy.blank("en")` (no model download), and `spacy` only ships in the heavy `multilingual` extra,
   so add the bare package rather than that whole extra.
@@ -93,10 +102,8 @@ stage2 = JobsPipelineExecutor(
             input_folder=f"{MINHASH_BASE_PATH}/signatures",
             output_folder=f"{MINHASH_BASE_PATH}/buckets",
             config=minhash_config,
-            # IMPORTANT on remote storage: the default (5) also sets the fsspec block_size to 5 lines
-            # (~340 bytes), i.e. one HTTP range request per couple of reads — measured ~40x slower on
-            # Jobs (65 min -> 99 s for this stage). -1 reads each signature file in a single request;
-            # it buffers whole files in RAM, so at very high task counts stage to local disk instead.
+            # -1 = read each signature file in ONE request instead of one per ~340 bytes (65 min → 99 s
+            # for this stage). RAM tradeoff + when NOT to use -1: see the note in the module docstring.
             lines_to_buffer=-1,
         ),
     ],

--- a/examples/minhash_deduplication_jobs.py
+++ b/examples/minhash_deduplication_jobs.py
@@ -29,9 +29,10 @@ general Slurm->Jobs comparison):
 - `dependencies` = `datatrove[io,processing]` PLUS `spacy`: the signature stage's English word tokenizer
   is `spacy.blank("en")` (no model download), and `spacy` only ships in the heavy `multilingual` extra,
   so add the bare package rather than that whole extra.
-- `max_retries >= 1` matters here: `hf://` has read-after-write lag, so a downstream stage can 404 on a
-  file the previous stage just wrote; a retry succeeds once it propagates. (Not needed on a strongly
-  consistent store.)
+- `max_retries >= 1` matters on `hf://datasets/` paths: dataset repos have read-after-write lag, so a
+  stage can 404 on a file just written — even its own (stage 1 re-reading a `.sig` it wrote milliseconds
+  earlier has been observed to 404); a retry succeeds once it propagates. Buckets and other strongly
+  consistent stores don't need it, but it's cheap insurance either way.
 - stage 1 and stage 4 MUST use the same input reader and the same task count (unchanged from Slurm).
 - Set `workers=N` on the stages to cap concurrent Jobs (the analog of Slurm's `%workers`).
 """
@@ -58,14 +59,17 @@ minhash_config = MinhashConfig(
     hashes_per_bucket=8,
 )  # better precision -> fewer false positives (collisions)
 
-# a shared REMOTE base path all four stages use (hf:// or s3://) — never a local path
-MINHASH_BASE_PATH = "hf://datasets/my_org/my-minhash"
-LOGS_FOLDER = "hf://datasets/my_org/my-minhash-logs"
+# a shared REMOTE base path all four stages use — never a local path. A Storage Bucket is the
+# recommended default (see module docstring); an hf://datasets/ repo works but is slower and
+# flakier for this inter-stage traffic.
+MINHASH_BASE_PATH = "hf://buckets/my_org/my-minhash/data"
+LOGS_FOLDER = "hf://buckets/my_org/my-minhash/logs"
 
 # datatrove + processing (nltk/xxhash/regex/tokenizers) + bare spacy (English word tokenizer).
-# Until JobsPipelineExecutor is released, install datatrove from your branch, e.g.:
-#   "datatrove[io,processing] @ git+https://github.com/<user>/datatrove@<branch>"
-DEPENDENCIES = ["datatrove[io,processing]", "spacy"]
+# Installed from git because no released datatrove ships JobsPipelineExecutor yet — with a
+# released version the Job dies at unpickle time (the class doesn't exist in the Job's env).
+# TODO: switch to "datatrove[io,processing]" once a release includes the Jobs executor.
+DEPENDENCIES = ["datatrove[io,processing] @ git+https://github.com/huggingface/datatrove", "spacy"]
 
 TOTAL_TASKS = 50
 
@@ -77,7 +81,7 @@ common = {
     "flavor": "cpu-basic",
     "dependencies": DEPENDENCIES,
     "timeout": "2h",
-    "max_retries": 2,  # tolerate transient hf:// read-after-write 404s between stages
+    "max_retries": 2,  # cheap insurance; required on hf://datasets/ paths (read-after-write 404s, see docstring)
 }
 
 # stage 1 computes minhash signatures for each task (each task gets a set of files)

--- a/examples/tokenize_hf_dataset_jobs.py
+++ b/examples/tokenize_hf_dataset_jobs.py
@@ -2,7 +2,7 @@
 Tokenize a Hugging Face dataset on Hugging Face Jobs, then merge-shuffle it into a single
 tokenized dataset ready for a training library.
 
-Note: `JobsPipelineExecutor` is experimental and its API may change in future releases.
+Note: `JobsPipelineExecutor` is experimental and may change, break, or be removed in future releases.
 
 The `JobsPipelineExecutor` twin of `tokenize_from_hf_to_s3.py` (which uses Slurm). Two stages:
 1. (fan-out) `HuggingFaceDatasetReader` -> `DocumentTokenizer`: each Job tokenizes + shuffles a shard.

--- a/examples/tokenize_hf_dataset_jobs.py
+++ b/examples/tokenize_hf_dataset_jobs.py
@@ -2,6 +2,8 @@
 Tokenize a Hugging Face dataset on Hugging Face Jobs, then merge-shuffle it into a single
 tokenized dataset ready for a training library.
 
+Note: `JobsPipelineExecutor` is experimental and its API may change in future releases.
+
 The `JobsPipelineExecutor` twin of `tokenize_from_hf_to_s3.py` (which uses Slurm). Two stages:
 1. (fan-out) `HuggingFaceDatasetReader` -> `DocumentTokenizer`: each Job tokenizes + shuffles a shard.
 2. (fan-in, `depends=` on stage 1) `DocumentTokenizerMerger`: merge-shuffle into the final files.

--- a/examples/tokenize_hf_dataset_jobs.py
+++ b/examples/tokenize_hf_dataset_jobs.py
@@ -1,0 +1,83 @@
+"""
+Tokenize a Hugging Face dataset on Hugging Face Jobs, then merge-shuffle it into a single
+tokenized dataset ready for a training library.
+
+The `JobsPipelineExecutor` twin of `tokenize_from_hf_to_s3.py` (which uses Slurm). Two stages:
+1. (fan-out) `HuggingFaceDatasetReader` -> `DocumentTokenizer`: each Job tokenizes + shuffles a shard.
+2. (fan-in, `depends=` on stage 1) `DocumentTokenizerMerger`: merge-shuffle into the final files.
+
+Same pipeline as the Slurm version; only the executor config differs (see `filter_hf_dataset_jobs.py`
+for the full comparison). Two things specific to this multi-stage flow on Jobs:
+- `output_path` MUST be a shared REMOTE path (hf:// or s3://) — both stages run on different machines
+  and read/write the same `tokenized-tasks/` folder.
+- The tokens pipeline needs the `processing` extra (there is no separate `tokens` extra): `tokenizers`
+  and `regex` live there. So `dependencies=["datatrove[io,processing]"]`.
+"""
+
+import argparse
+import os.path
+
+
+parser = argparse.ArgumentParser("Tokenize an HF dataset on HF Jobs")
+parser.add_argument("dataset", type=str, help="HF dataset name, e.g. stanfordnlp/imdb")
+parser.add_argument(
+    "output_path", type=str, help="REMOTE base path (e.g. hf://datasets/<you>/<name>) for tokenized + merged files"
+)
+parser.add_argument("-t", "--tokenizer", type=str, help="tokenizer to use", default="gpt2")
+parser.add_argument("-s", "--split", type=str, help="dataset split", default="train")
+parser.add_argument("-tk", "--text_key", type=str, help="text column", default="text")
+parser.add_argument("-ts", "--tasks", type=int, help="number of tokenization tasks", default=100)
+parser.add_argument("--workers", type=int, help="max concurrent Jobs (-1 = all at once)", default=20)
+parser.add_argument("--flavor", type=str, help="HF Jobs hardware flavor", default="cpu-basic")
+
+# tokens machinery lives in the `processing` extra (tokenizers + regex); `datasets` comes from `io`.
+# Until JobsPipelineExecutor is released, install datatrove from your branch, e.g.:
+#   "datatrove[io,processing] @ git+https://github.com/<user>/datatrove@<branch>"
+DEPENDENCIES = ["datatrove[io,processing]"]
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    from datatrove.executor import JobsPipelineExecutor
+    from datatrove.pipeline.readers import HuggingFaceDatasetReader
+    from datatrove.pipeline.tokens.merger import DocumentTokenizerMerger
+    from datatrove.pipeline.tokens.tokenizer import DocumentTokenizer
+
+    name = f"{args.dataset}-{args.tokenizer}".replace("/", "_")
+    working_dir = os.path.join(args.output_path, "tokenized-tasks")  # shared remote path — both stages read it
+    final_dir = os.path.join(args.output_path, "merged-dataset")  # the path you pass to your training library
+
+    tokenize = JobsPipelineExecutor(
+        job_name=f"{name}-tok1",
+        pipeline=[
+            HuggingFaceDatasetReader(
+                dataset=args.dataset,
+                dataset_options={"split": args.split},
+                text_key=args.text_key,
+            ),
+            DocumentTokenizer(
+                output_folder=working_dir,
+                local_working_dir="/tmp/datatrove-tokenize",  # Job-local scratch (ephemeral); staged then uploaded
+                save_filename=f"{name}_tokenized",
+                tokenizer_name_or_path=args.tokenizer,
+            ),
+        ],
+        tasks=args.tasks,
+        workers=args.workers,
+        logging_dir=os.path.join(args.output_path, "logs", "tokenization"),
+        flavor=args.flavor,
+        dependencies=DEPENDENCIES,
+        timeout="2h",
+    )
+
+    merge = JobsPipelineExecutor(
+        job_name=f"{name}-tok2",
+        pipeline=[DocumentTokenizerMerger(input_folder=working_dir, output_folder=final_dir, save_filename=name)],
+        tasks=1,  # important: the merger is a single fan-in task
+        logging_dir=os.path.join(args.output_path, "logs", "merged"),
+        flavor=args.flavor,
+        dependencies=DEPENDENCIES,
+        timeout="2h",
+        depends=tokenize,  # <-- launches + waits for all tokenization tasks, then merges
+    )
+
+    merge.run()

--- a/examples/tokenize_hf_dataset_jobs.py
+++ b/examples/tokenize_hf_dataset_jobs.py
@@ -33,9 +33,10 @@ parser.add_argument("--workers", type=int, help="max concurrent Jobs (-1 = all a
 parser.add_argument("--flavor", type=str, help="HF Jobs hardware flavor", default="cpu-basic")
 
 # tokens machinery lives in the `processing` extra (tokenizers + regex); `datasets` comes from `io`.
-# Until JobsPipelineExecutor is released, install datatrove from your branch, e.g.:
-#   "datatrove[io,processing] @ git+https://github.com/<user>/datatrove@<branch>"
-DEPENDENCIES = ["datatrove[io,processing]"]
+# Installed from git because no released datatrove ships JobsPipelineExecutor yet — with a
+# released version the Job dies at unpickle time (the class doesn't exist in the Job's env).
+# TODO: switch to "datatrove[io,processing]" once a release includes the Jobs executor.
+DEPENDENCIES = ["datatrove[io,processing] @ git+https://github.com/huggingface/datatrove"]
 
 if __name__ == "__main__":
     args = parser.parse_args()

--- a/src/datatrove/executor/__init__.py
+++ b/src/datatrove/executor/__init__.py
@@ -1,3 +1,4 @@
+from .jobs import JobsPipelineExecutor
 from .local import LocalPipelineExecutor
 from .ray import RayPipelineExecutor
 from .slurm import SlurmPipelineExecutor

--- a/src/datatrove/executor/jobs.py
+++ b/src/datatrove/executor/jobs.py
@@ -15,7 +15,7 @@ import dill
 from dill import CONTENTS_FMODE
 
 from datatrove.executor.base import DistributedEnvVars, PipelineExecutor
-from datatrove.io import DataFolderLike, get_datafolder
+from datatrove.io import DataFolderLike, _get_true_fs, get_datafolder
 from datatrove.pipeline.base import PipelineStep
 from datatrove.utils.logging import add_task_logger, close_task_logger, log_pipeline, logger
 from datatrove.utils.stats import PipelineStats
@@ -78,6 +78,8 @@ class JobsPipelineExecutor(PipelineExecutor):
             here by a local polling loop.
         logging_dir: where to save logs, stats, completions and the pickled executor.
             Must resolve to a *remote* datatrove.io.DataFolder (``hf://`` or ``s3://``).
+            An ``hf://`` repo/bucket is created automatically (private) if it doesn't exist
+            yet; an ``s3://`` bucket must already exist.
         flavor: Hugging Face Jobs hardware flavor for each Job (default ``"cpu-basic"``).
         image: optional Docker image for the Jobs. Defaults to the huggingface_hub uv
             image. A custom image must have ``uv`` installed.
@@ -250,6 +252,7 @@ class JobsPipelineExecutor(PipelineExecutor):
                 time.sleep(2 * 60)
             self.depends = None  # avoid pickling the dependency chain
 
+        self._ensure_logging_dir_repo()
         ranks_to_run = self.get_incomplete_ranks()
         if len(ranks_to_run) == 0:
             logger.info(f"Skipping launch of {self.job_name} as all {self.tasks} tasks have already been completed.")
@@ -292,6 +295,26 @@ class JobsPipelineExecutor(PipelineExecutor):
             # this run's failed ranks and produce a stats.json mixing old and new per-rank data
             return
         self._merge_stats()
+
+    def _ensure_logging_dir_repo(self):
+        """Create the Hub repo/bucket backing an ``hf://`` logging_dir if it doesn't exist yet.
+
+        The *output* repo auto-creates via its writer, but nothing creates the logging repo — without
+        this, a fresh run crashes on the very first ``completions/`` listing with "repository not
+        found". Non-hf filesystems (e.g. ``s3://``) are left untouched: the bucket must already exist.
+        """
+        from huggingface_hub import HfFileSystem, create_bucket, create_repo
+
+        if not isinstance(_get_true_fs(self.logging_dir.fs), HfFileSystem):
+            return
+        # DirFileSystem stripped the protocol: "buckets/<ns>/<bucket>/..." or "[<type>s/]<ns>/<repo>[@rev]/..."
+        parts = self.logging_dir.path.split("/")
+        if parts[0] == "buckets":
+            create_bucket("/".join(parts[1:3]), private=True, exist_ok=True, token=self.token)
+        else:
+            repo_type, offset = {"datasets": ("dataset", 1), "spaces": ("space", 1)}.get(parts[0], ("model", 0))
+            repo_id = "/".join(parts[offset : offset + 2]).split("@", 1)[0]
+            create_repo(repo_id, private=True, repo_type=repo_type, exist_ok=True, token=self.token)
 
     def save_executor_as_json(self, indent: int = 4):
         """Same as the base version, but never persists credentials into the (shared) logging_dir."""

--- a/src/datatrove/executor/jobs.py
+++ b/src/datatrove/executor/jobs.py
@@ -31,8 +31,8 @@ _SUCCESS_JOB_STAGE = "COMPLETED"
 class JobsPipelineExecutor(PipelineExecutor):
     """Execute a pipeline on Hugging Face Jobs.
 
-    **Experimental**: this executor is experimental and its API may change (or break) in
-    future releases without the usual deprecation cycle.
+    **Experimental**: this executor is experimental — it may change, break, or be removed
+    in future releases without the usual deprecation cycle.
 
     Fans a datatrove pipeline out across a pool of Hugging Face Jobs, mirroring
     :class:`~datatrove.executor.slurm.SlurmPipelineExecutor` but launching Jobs with
@@ -150,7 +150,7 @@ class JobsPipelineExecutor(PipelineExecutor):
         run_on_dependency_fail: bool = False,
         job_name: str = "data_processing",
     ):
-        logger.warning("JobsPipelineExecutor is experimental: its API may change (or break) in future releases.")
+        logger.warning("JobsPipelineExecutor is experimental: it may change, break, or be removed in future releases.")
         super().__init__(pipeline, logging_dir, skip_completed, randomize_start_duration)
         if self.logging_dir.is_local():
             raise ValueError(

--- a/src/datatrove/executor/jobs.py
+++ b/src/datatrove/executor/jobs.py
@@ -177,7 +177,11 @@ class JobsPipelineExecutor(PipelineExecutor):
         if start >= len(all_ranks):
             logger.info(f"Array index {array_index} has no ranks to run.")
             return
+        # deepcopy the pipeline before each rank so per-rank stats and step state don't accumulate
+        # across ranks that share this Job's process (mirrors LocalPipelineExecutor's workers==1 path).
+        base_pipeline = self.pipeline
         for i in range(start, min(start + self.tasks_per_job, len(all_ranks))):
+            self.pipeline = deepcopy(base_pipeline)
             self._run_for_rank(all_ranks[i])
 
     def launch_job(self):

--- a/src/datatrove/executor/jobs.py
+++ b/src/datatrove/executor/jobs.py
@@ -98,9 +98,12 @@ class JobsPipelineExecutor(PipelineExecutor):
         labels: extra labels attached to each Job.
         token: Hugging Face token. Defaults to the locally saved login. Passed to each Job
             as the ``HF_TOKEN`` secret so it can read/write the logging_dir.
-        secrets: extra secrets passed to each Job (merged with the ``HF_TOKEN`` secret).
+        secrets: extra secrets passed to each Job (merged with the ``HF_TOKEN`` secret; an
+            ``HF_TOKEN`` key here overrides the resolved token).
         max_retries: how many times to relaunch a Job that ends in a non-success state
-            within a single run (default 1).
+            within a single run (default 1). Ranks still failed after that are logged and
+            left incomplete — :meth:`run` does NOT raise; rerun to resume. A dependent
+            executor (``depends=``) fails fast on them instead.
         poll_interval: seconds between polls of the running Jobs (default 15).
         run_on_dependency_fail: if a ``depends`` job finishes with failed (permanently incomplete) tasks,
             continue anyway instead of raising. Default False (fail fast, like Slurm's ``afterok``).
@@ -321,7 +324,7 @@ class JobsPipelineExecutor(PipelineExecutor):
                 **(self.labels or {}),
             },
             namespace=self.namespace,
-            token=self.token,
+            token=token,
         )
         logger.info(f"Launched array index {array_index} as Job {job.id} ({job.url}).")
         return job.id
@@ -344,7 +347,7 @@ class JobsPipelineExecutor(PipelineExecutor):
         while running:
             time.sleep(self.poll_interval)
             for job_id in list(running):
-                stage = inspect_job(job_id=job_id, namespace=self.namespace, token=self.token).status.stage
+                stage = inspect_job(job_id=job_id, namespace=self.namespace, token=token).status.stage
                 if stage not in _TERMINAL_JOB_STAGES:
                     continue
                 idx = running.pop(job_id)

--- a/src/datatrove/executor/jobs.py
+++ b/src/datatrove/executor/jobs.py
@@ -53,6 +53,14 @@ class JobsPipelineExecutor(PipelineExecutor):
     ranks are relaunched. This replaces Slurm's requeue / ``SIGUSR1`` handling, which has no
     Jobs equivalent.
 
+    Note: the launching process (the "coordinator") currently runs **locally** and stays alive for
+    the whole run — it submits the Jobs, polls them to honor ``workers``, and merges stats at the
+    end (the same launch-and-block model as Local/Ray; only Slurm is fire-and-forget). Only the
+    compute is remote. If the coordinator is interrupted, in-flight Jobs still finish and record
+    their ranks; just rerun to launch the rest (resume is idempotent). Running the coordinator
+    itself inside a Job, so nothing needs to stay on the launching machine, is a possible future
+    enhancement.
+
     [!] do not launch Jobs from within a Job.
 
     Args:

--- a/src/datatrove/executor/jobs.py
+++ b/src/datatrove/executor/jobs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import random
 import tempfile
 import time
 from collections import deque
@@ -54,7 +55,9 @@ class JobsPipelineExecutor(PipelineExecutor):
     Because completion is tracked with ``completions/{rank:05d}`` marker files, reruns are
     idempotent: already-completed ranks are skipped and only the Jobs for the remaining
     ranks are relaunched. This replaces Slurm's requeue / ``SIGUSR1`` handling, which has no
-    Jobs equivalent.
+    Jobs equivalent. Before rerunning, make sure no Jobs from a previous launch are still
+    queued or running (cancel them first): each launch rewrites ``executor.pik`` and
+    ``ranks_to_run.json``, which stale Jobs would then read.
 
     Note: the launching process (the "coordinator") currently runs **locally** and stays alive for
     the whole run — it submits the Jobs, polls them to honor ``workers``, and merges stats at the
@@ -155,6 +158,10 @@ class JobsPipelineExecutor(PipelineExecutor):
                 "s3://<bucket>) that both the launching machine and the Jobs can access. Got a local "
                 f"path: {self.logging_dir.path!r}."
             )
+        if tasks_per_job < 1:
+            raise ValueError(f"tasks_per_job must be >= 1, got {tasks_per_job}.")
+        if workers != -1 and workers < 1:
+            raise ValueError(f"workers must be -1 (unlimited) or >= 1, got {workers}.")
         self.tasks = tasks
         self.workers = workers
         self.flavor = flavor
@@ -244,10 +251,16 @@ class JobsPipelineExecutor(PipelineExecutor):
         if len(ranks_to_run) == 0:
             logger.info(f"Skipping launch of {self.job_name} as all {self.tasks} tasks have already been completed.")
             self._launched = True
+            if not self.logging_dir.isfile("stats.json"):
+                self._merge_stats()  # a previous coordinator may have died after the last rank completed
             return
 
         # pickle ourselves; each Job rehydrates this via `launch_pickled_pipeline` and calls run()
         executor = deepcopy(self)
+        # never persist credentials into the (shared) logging_dir: the Jobs get HF_TOKEN and any user
+        # secrets as Job secrets instead (see _submit_array_index)
+        executor.token = None
+        executor.secrets = None
         with self.logging_dir.open("executor.pik", "wb") as executor_f:
             dill.dump(executor, executor_f, fmode=CONTENTS_FMODE)
         self.save_executor_as_json()
@@ -272,6 +285,15 @@ class JobsPipelineExecutor(PipelineExecutor):
         self._launched = True
         self._launch_and_wait(nb_jobs, pik_path, max_concurrent, token)
         self._merge_stats()
+
+    def save_executor_as_json(self, indent: int = 4):
+        """Same as the base version, but never persists credentials into the (shared) logging_dir."""
+        token, secrets = self.token, self.secrets
+        self.token = self.secrets = None
+        try:
+            super().save_executor_as_json(indent=indent)
+        finally:
+            self.token, self.secrets = token, secrets
 
     def _submit_array_index(self, array_index: int, pik_path: str, token: str) -> str:
         """Launch a single Hugging Face Job for one array index; returns its job id."""
@@ -352,7 +374,8 @@ class JobsPipelineExecutor(PipelineExecutor):
         """Merge per-rank stats into ``stats.json`` once every task is complete."""
         # the Jobs wrote completions/ + stats/ remotely; refresh the launcher's cached listing first
         self.logging_dir.fs.invalidate_cache()
-        incomplete = self.get_incomplete_ranks(range(self.world_size))
+        # check the actual completion markers even when skip_completed=False
+        incomplete = self.get_incomplete_ranks(range(self.world_size), skip_completed=True)
         if incomplete:
             logger.warning(
                 f"{len(incomplete)}/{self.world_size} tasks still incomplete; not merging stats. Rerun to resume."
@@ -378,6 +401,8 @@ class JobsPipelineExecutor(PipelineExecutor):
             return PipelineStats()
 
         self._set_distributed_environment(node_rank)
+        if self.randomize_start_duration > 0:
+            time.sleep(random.randint(0, self.randomize_start_duration))
 
         # log locally and upload the log to logging_dir once the pipeline finishes
         local_logs_dir = get_datafolder(f"{tempfile.gettempdir()}/datatrove_jobs_logs")

--- a/src/datatrove/executor/jobs.py
+++ b/src/datatrove/executor/jobs.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+import tempfile
+import time
+from collections import deque
+from collections.abc import Callable, Sequence
+from copy import deepcopy
+from typing import Any
+
+import dill
+from dill import CONTENTS_FMODE
+
+from datatrove.executor.base import DistributedEnvVars, PipelineExecutor
+from datatrove.io import DataFolderLike, get_datafolder
+from datatrove.pipeline.base import PipelineStep
+from datatrove.utils.logging import add_task_logger, close_task_logger, log_pipeline, logger
+from datatrove.utils.stats import PipelineStats
+
+
+# Set on each launched Job to tell the worker which slice of `ranks_to_run.json` it owns.
+ARRAY_INDEX_ENV_VAR = "DATATROVE_JOB_ARRAY_INDEX"
+# Mirror of huggingface_hub._jobs_api.TERMINAL_JOB_STAGES, duplicated to avoid importing a private symbol.
+_TERMINAL_JOB_STAGES = ("COMPLETED", "ERROR", "CANCELED", "DELETED")
+_SUCCESS_JOB_STAGE = "COMPLETED"
+
+
+class JobsPipelineExecutor(PipelineExecutor):
+    """Execute a pipeline on Hugging Face Jobs.
+
+    Fans a datatrove pipeline out across a pool of Hugging Face Jobs, mirroring
+    :class:`~datatrove.executor.slurm.SlurmPipelineExecutor` but launching Jobs with
+    ``huggingface_hub.run_uv_job`` instead of calling ``sbatch``.
+
+    Like the Slurm executor, :meth:`run` is two-phase: when it detects it is running
+    *inside* a launched Job (the ``DATATROVE_JOB_ARRAY_INDEX`` env var is set) it runs its
+    assigned block of ranks; otherwise it launches the Jobs. All coordination happens
+    through the shared fsspec ``logging_dir`` (``executor.pik``, ``ranks_to_run.json``,
+    ``completions/``, ``stats/``), so it MUST point to a *remote* folder that both the
+    launching machine and the Jobs can read/write (e.g. ``hf://datasets/<repo>`` or
+    ``s3://<bucket>``).
+
+    Each Job runs ``launch_pickled_pipeline <logging_dir>/executor.pik`` in a ``uv``
+    environment built from ``dependencies``; that rehydrates this executor and calls
+    :meth:`run`, which — with ``DATATROVE_JOB_ARRAY_INDEX`` set — runs the Job's block of
+    ranks. Concurrency (Slurm's ``%workers`` array throttle) is enforced by a local polling
+    loop that keeps at most ``workers`` Jobs alive at a time.
+
+    Because completion is tracked with ``completions/{rank:05d}`` marker files, reruns are
+    idempotent: already-completed ranks are skipped and only the Jobs for the remaining
+    ranks are relaunched. This replaces Slurm's requeue / ``SIGUSR1`` handling, which has no
+    Jobs equivalent.
+
+    [!] do not launch Jobs from within a Job.
+
+    Args:
+        pipeline: a list of PipelineStep and/or custom functions with arguments
+            (data: DocumentsPipeline, rank: int, world_size: int).
+        tasks: total number of tasks (the world_size to shard the pipeline over).
+        workers: how many Jobs to run simultaneously. -1 (default) launches them all at
+            once. This is the equivalent of Slurm's ``%workers`` array throttle, enforced
+            here by a local polling loop.
+        logging_dir: where to save logs, stats, completions and the pickled executor.
+            Must resolve to a *remote* datatrove.io.DataFolder (``hf://`` or ``s3://``).
+        flavor: Hugging Face Jobs hardware flavor for each Job (default ``"cpu-basic"``).
+        image: optional Docker image for the Jobs. Defaults to the huggingface_hub uv
+            image. A custom image must have ``uv`` installed.
+        dependencies: pip requirements installed in each Job's ``uv`` environment (passed
+            as ``uv run --with``). Must include datatrove and anything your pipeline steps
+            import (e.g. ``"datasets"``). Defaults to ``["datatrove[io]"]``; until this
+            executor is released, point datatrove at the branch, e.g.
+            ``["datatrove[io] @ git+https://github.com/<user>/datatrove@<branch>", "datasets"]``.
+        timeout: per-Job timeout, as seconds (int) or a string like ``"2h"`` / ``"30m"``.
+        tasks_per_job: how many datatrove tasks each Job runs. Reduces the number of Jobs
+            launched (default 1).
+        depends: another JobsPipelineExecutor that must finish before this one starts.
+        skip_completed: whether to skip tasks completed in previous runs (default True).
+        randomize_start_duration: max seconds to randomly delay the start of each task.
+        python: Python version for the Job's ``uv`` environment (e.g. ``"3.12"``).
+        namespace: Hugging Face namespace to launch the Jobs under (defaults to the
+            authenticated user).
+        labels: extra labels attached to each Job.
+        token: Hugging Face token. Defaults to the locally saved login. Passed to each Job
+            as the ``HF_TOKEN`` secret so it can read/write the logging_dir.
+        secrets: extra secrets passed to each Job (merged with the ``HF_TOKEN`` secret).
+        max_retries: how many times to relaunch a Job that ends in a non-success state
+            within a single run (default 1).
+        poll_interval: seconds between polls of the running Jobs (default 15).
+        job_name: name used for logging and as a Job label (default ``"data_processing"``).
+
+    Example:
+        ```python
+        from datatrove.executor import JobsPipelineExecutor
+        from datatrove.pipeline.readers import HuggingFaceDatasetReader
+        from datatrove.pipeline.writers import ParquetWriter
+
+        JobsPipelineExecutor(
+            pipeline=[
+                HuggingFaceDatasetReader("stanfordnlp/imdb", dataset_options={"split": "train"}),
+                ParquetWriter("hf://datasets/<user>/imdb-processed/data"),
+            ],
+            tasks=10,
+            workers=4,
+            logging_dir="hf://datasets/<user>/imdb-processed/logs",
+            dependencies=["datatrove[io]", "datasets"],
+            flavor="cpu-basic",
+        ).run()
+        ```
+    """
+
+    def __init__(
+        self,
+        pipeline: list[PipelineStep | Callable],
+        tasks: int,
+        workers: int = -1,
+        logging_dir: DataFolderLike = None,
+        flavor: str = "cpu-basic",
+        image: str | None = None,
+        dependencies: list[str] | None = None,
+        timeout: int | float | str | None = None,
+        tasks_per_job: int = 1,
+        depends: "JobsPipelineExecutor | None" = None,
+        skip_completed: bool = True,
+        randomize_start_duration: int = 0,
+        python: str | None = None,
+        namespace: str | None = None,
+        labels: dict[str, str] | None = None,
+        token: str | None = None,
+        secrets: dict[str, Any] | None = None,
+        max_retries: int = 1,
+        poll_interval: int = 15,
+        job_name: str = "data_processing",
+    ):
+        super().__init__(pipeline, logging_dir, skip_completed, randomize_start_duration)
+        if self.logging_dir.is_local():
+            raise ValueError(
+                "JobsPipelineExecutor requires a remote logging_dir (e.g. hf://datasets/<repo> or "
+                "s3://<bucket>) that both the launching machine and the Jobs can access. Got a local "
+                f"path: {self.logging_dir.path!r}."
+            )
+        self.tasks = tasks
+        self.workers = workers
+        self.flavor = flavor
+        self.image = image
+        self.dependencies = dependencies if dependencies is not None else ["datatrove[io]"]
+        self.timeout = timeout
+        self.tasks_per_job = tasks_per_job
+        self.depends = depends
+        self.python = python
+        self.namespace = namespace
+        self.labels = labels
+        self.token = token
+        self.secrets = secrets
+        self.max_retries = max_retries
+        self.poll_interval = poll_interval
+        self.job_name = job_name
+        self._launched = False
+
+    def run(self):
+        """Run the pipeline.
+
+        Two-phase: inside a launched Job (``DATATROVE_JOB_ARRAY_INDEX`` set) run the block of
+        ranks assigned to that Job; otherwise launch the Jobs.
+        """
+        if ARRAY_INDEX_ENV_VAR in os.environ:
+            self._run_array_index(int(os.environ[ARRAY_INDEX_ENV_VAR]))
+        else:
+            self.launch_job()
+
+    def _run_array_index(self, array_index: int):
+        """Run the block of ranks assigned to one Job, identified by its array index."""
+        with self.logging_dir.open("ranks_to_run.json", "r") as f:
+            all_ranks = json.load(f)
+        start = array_index * self.tasks_per_job
+        if start >= len(all_ranks):
+            logger.info(f"Array index {array_index} has no ranks to run.")
+            return
+        for i in range(start, min(start + self.tasks_per_job, len(all_ranks))):
+            self._run_for_rank(all_ranks[i])
+
+    def launch_job(self):
+        """Pickle this executor and fan it out across a pool of Hugging Face Jobs."""
+        from huggingface_hub import get_token
+
+        assert not self.depends or isinstance(self.depends, JobsPipelineExecutor), (
+            "depends= must be a JobsPipelineExecutor"
+        )
+        if self.depends:
+            # launch any unlaunched dependency, then poll its completions until it is done
+            if not self.depends._launched:
+                logger.info(f'Launching dependency job "{self.depends.job_name}"')
+                self.depends.launch_job()
+            while (incomplete := len(self.depends.get_incomplete_ranks(skip_completed=True))) > 0:
+                logger.info(f"Dependency job still has {incomplete}/{self.depends.world_size} tasks. Waiting...")
+                time.sleep(2 * 60)
+            self.depends = None  # avoid pickling the dependency chain
+
+        ranks_to_run = self.get_incomplete_ranks()
+        if len(ranks_to_run) == 0:
+            logger.info(f"Skipping launch of {self.job_name} as all {self.tasks} tasks have already been completed.")
+            self._launched = True
+            return
+
+        # pickle ourselves; each Job rehydrates this via `launch_pickled_pipeline` and calls run()
+        executor = deepcopy(self)
+        with self.logging_dir.open("executor.pik", "wb") as executor_f:
+            dill.dump(executor, executor_f, fmode=CONTENTS_FMODE)
+        self.save_executor_as_json()
+        with self.logging_dir.open("ranks_to_run.json", "w") as ranks_to_run_file:
+            # saved once to avoid races: array index i owns ranks_to_run[i*tasks_per_job:(i+1)*tasks_per_job]
+            json.dump(ranks_to_run, ranks_to_run_file)
+
+        nb_jobs = math.ceil(len(ranks_to_run) / self.tasks_per_job)
+        max_concurrent = self.workers if self.workers != -1 else nb_jobs
+        pik_path = self.logging_dir.resolve_paths("executor.pik")
+        token = self.token or get_token()
+        if token is None:
+            raise ValueError(
+                "No Hugging Face token found. Log in with `hf auth login` or pass token=... so the Jobs "
+                "can read/write the logging_dir."
+            )
+
+        logger.info(
+            f"Launching {nb_jobs} Hugging Face Job(s) for '{self.job_name}' ({len(ranks_to_run)} tasks, "
+            f"{self.tasks_per_job} per job, up to {max_concurrent} concurrent) on flavor '{self.flavor}'."
+        )
+        self._launched = True
+        self._launch_and_wait(nb_jobs, pik_path, max_concurrent, token)
+        self._merge_stats()
+
+    def _submit_array_index(self, array_index: int, pik_path: str, token: str) -> str:
+        """Launch a single Hugging Face Job for one array index; returns its job id."""
+        from huggingface_hub import run_uv_job
+
+        from datatrove.tools import launch_pickled_pipeline
+
+        job = run_uv_job(
+            launch_pickled_pipeline.__file__,  # uploaded + run as `uv run launch_pickled_pipeline.py <pik>`
+            script_args=[pik_path],
+            dependencies=self.dependencies,
+            python=self.python,
+            image=self.image,
+            env={
+                ARRAY_INDEX_ENV_VAR: str(array_index),
+                "HF_HUB_DISABLE_PROGRESS_BARS": "1",
+                "PYTHONUNBUFFERED": "1",
+            },
+            secrets={"HF_TOKEN": token, **(self.secrets or {})},
+            flavor=self.flavor,
+            timeout=self.timeout,
+            labels={
+                "datatrove_job_name": self.job_name,
+                "datatrove_array_index": str(array_index),
+                **(self.labels or {}),
+            },
+            namespace=self.namespace,
+            token=self.token,
+        )
+        logger.info(f"Launched array index {array_index} as Job {job.id} ({job.url}).")
+        return job.id
+
+    def _launch_and_wait(self, nb_jobs: int, pik_path: str, max_concurrent: int, token: str):
+        """Local window-manager: keep at most ``max_concurrent`` Jobs live until every index finishes."""
+        from huggingface_hub import inspect_job
+
+        pending: deque[int] = deque(range(nb_jobs))
+        running: dict[str, int] = {}  # job_id -> array_index
+        retries: dict[int, int] = {}
+        failed: list[int] = []
+
+        def fill():
+            while pending and len(running) < max_concurrent:
+                idx = pending.popleft()
+                running[self._submit_array_index(idx, pik_path, token)] = idx
+
+        fill()
+        while running:
+            time.sleep(self.poll_interval)
+            for job_id in list(running):
+                stage = inspect_job(job_id=job_id, namespace=self.namespace, token=self.token).status.stage
+                if stage not in _TERMINAL_JOB_STAGES:
+                    continue
+                idx = running.pop(job_id)
+                if stage == _SUCCESS_JOB_STAGE:
+                    logger.info(f"Job {job_id} (array index {idx}) completed.")
+                elif retries.get(idx, 0) < self.max_retries:
+                    retries[idx] = retries.get(idx, 0) + 1
+                    logger.warning(
+                        f"Job {job_id} (array index {idx}) ended as {stage}; "
+                        f"resubmitting ({retries[idx]}/{self.max_retries})."
+                    )
+                    pending.append(idx)
+                else:
+                    logger.error(
+                        f"Job {job_id} (array index {idx}) failed as {stage} after {retries.get(idx, 0)} retries."
+                    )
+                    failed.append(idx)
+            fill()
+
+        if failed:
+            logger.warning(
+                f"{len(failed)} Job(s) failed after retries (array indices {failed}). Incomplete ranks will be "
+                f"retried on the next run (completed ranks are skipped)."
+            )
+
+    def _merge_stats(self):
+        """Merge per-rank stats into ``stats.json`` once every task is complete."""
+        incomplete = self.get_incomplete_ranks(range(self.world_size))
+        if incomplete:
+            logger.warning(
+                f"{len(incomplete)}/{self.world_size} tasks still incomplete; not merging stats. Rerun to resume."
+            )
+            return
+        total_stats = PipelineStats()
+        for rank in range(self.world_size):
+            with self.logging_dir.open(f"stats/{rank:05d}.json", "r") as f:
+                total_stats += PipelineStats.from_json(json.load(f))
+        with self.logging_dir.open("stats.json", "wt") as f:
+            total_stats.save_to_disk(f)
+        logger.success(total_stats.get_repr(f"All {self.world_size} tasks."))
+
+    def _run_for_rank(self, rank: int, local_rank: int = 0, node_rank: int = -1) -> PipelineStats:
+        """Run one rank, logging to a local tempdir and uploading the log to ``logging_dir`` on finish.
+
+        Overrides the base method because the remote (object-store) ``logging_dir`` is a poor target for
+        the incrementally-written task log; per-rank stats and the completion marker are still written
+        straight to ``logging_dir``. Mirrors ``RayPipelineExecutor._run_for_rank``.
+        """
+        if self.is_rank_completed(rank):
+            logger.info(f"Skipping {rank=} as it has already been completed.")
+            return PipelineStats()
+
+        self._set_distributed_environment(node_rank)
+
+        # log locally and upload the log to logging_dir once the pipeline finishes
+        local_logs_dir = get_datafolder(f"{tempfile.gettempdir()}/datatrove_jobs_logs")
+        logfile = add_task_logger(local_logs_dir, rank, local_rank, node_rank=node_rank)
+        log_pipeline(self.pipeline)
+
+        stats = PipelineStats()
+        try:
+            # pipe data from one step to the next
+            pipelined_data = None
+            for pipeline_step in self.pipeline:
+                if callable(pipeline_step):
+                    pipelined_data = pipeline_step(pipelined_data, rank, self.world_size)
+                elif isinstance(pipeline_step, Sequence) and not isinstance(pipeline_step, str):
+                    pipelined_data = pipeline_step
+                else:
+                    raise ValueError
+            if pipelined_data:
+                deque(pipelined_data, maxlen=0)
+
+            logger.success(f"Processing done for {rank=}")
+
+            stats = PipelineStats(self.pipeline)
+            if node_rank <= 0:
+                with self.logging_dir.open(f"stats/{rank:05d}.json", "w") as f:
+                    stats.save_to_disk(f)
+                logger.info(stats.get_repr(f"Task {rank}"))
+                self.mark_rank_as_completed(rank)
+        except Exception as e:
+            logger.exception(e)
+            raise e
+        finally:
+            close_task_logger(logfile)
+            with (
+                local_logs_dir.open(f"logs/task_{rank:05d}.log", "r") as f,
+                self.logging_dir.open(f"logs/task_{rank:05d}.log", "w") as f_out,
+            ):
+                f_out.write(f.read())
+        return stats
+
+    def get_distributed_env(self, node_rank: int = -1) -> DistributedEnvVars:
+        """Distributed env vars for the JOBS executor (each Job is a single node)."""
+        return DistributedEnvVars(
+            datatrove_node_ips="localhost",
+            datatrove_cpus_per_task="-1",
+            datatrove_mem_per_cpu="-1",
+            datatrove_gpus_on_node="-1",
+            datatrove_executor="JOBS",
+        )
+
+    @property
+    def world_size(self) -> int:
+        return self.tasks

--- a/src/datatrove/executor/jobs.py
+++ b/src/datatrove/executor/jobs.py
@@ -286,7 +286,11 @@ class JobsPipelineExecutor(PipelineExecutor):
             f"{self.tasks_per_job} per job, up to {max_concurrent} concurrent) on flavor '{self.flavor}'."
         )
         self._launched = True
-        self._launch_and_wait(nb_jobs, pik_path, max_concurrent, token)
+        failed = self._launch_and_wait(nb_jobs, pik_path, max_concurrent, token)
+        if failed:
+            # don't merge: with skip_completed=False, markers left by a previous run could mask
+            # this run's failed ranks and produce a stats.json mixing old and new per-rank data
+            return
         self._merge_stats()
 
     def save_executor_as_json(self, indent: int = 4):
@@ -329,8 +333,11 @@ class JobsPipelineExecutor(PipelineExecutor):
         logger.info(f"Launched array index {array_index} as Job {job.id} ({job.url}).")
         return job.id
 
-    def _launch_and_wait(self, nb_jobs: int, pik_path: str, max_concurrent: int, token: str):
-        """Local window-manager: keep at most ``max_concurrent`` Jobs live until every index finishes."""
+    def _launch_and_wait(self, nb_jobs: int, pik_path: str, max_concurrent: int, token: str) -> list[int]:
+        """Local window-manager: keep at most ``max_concurrent`` Jobs live until every index finishes.
+
+        Returns the array indices that still failed after ``max_retries``.
+        """
         from huggingface_hub import inspect_job
 
         pending: deque[int] = deque(range(nb_jobs))
@@ -372,6 +379,7 @@ class JobsPipelineExecutor(PipelineExecutor):
                 f"{len(failed)} Job(s) failed after retries (array indices {failed}). Incomplete ranks will be "
                 f"retried on the next run (completed ranks are skipped)."
             )
+        return failed
 
     def _merge_stats(self):
         """Merge per-rank stats into ``stats.json`` once every task is complete."""

--- a/src/datatrove/executor/jobs.py
+++ b/src/datatrove/executor/jobs.py
@@ -43,8 +43,8 @@ class JobsPipelineExecutor(PipelineExecutor):
     assigned block of ranks; otherwise it launches the Jobs. All coordination happens
     through the shared fsspec ``logging_dir`` (``executor.pik``, ``ranks_to_run.json``,
     ``completions/``, ``stats/``), so it MUST point to a *remote* folder that both the
-    launching machine and the Jobs can read/write (e.g. ``hf://datasets/<repo>`` or
-    ``s3://<bucket>``).
+    launching machine and the Jobs can read/write (e.g. ``hf://buckets/<user>/<bucket>/...``
+    (huggingface_hub>=1.6.0), ``hf://datasets/<repo>`` or ``s3://<bucket>``).
 
     Each Job runs ``launch_pickled_pipeline <logging_dir>/executor.pik`` in a ``uv``
     environment built from ``dependencies``; that rehydrates this executor and calls

--- a/src/datatrove/executor/jobs.py
+++ b/src/datatrove/executor/jobs.py
@@ -96,6 +96,8 @@ class JobsPipelineExecutor(PipelineExecutor):
         max_retries: how many times to relaunch a Job that ends in a non-success state
             within a single run (default 1).
         poll_interval: seconds between polls of the running Jobs (default 15).
+        run_on_dependency_fail: if a ``depends`` job finishes with failed (permanently incomplete) tasks,
+            continue anyway instead of raising. Default False (fail fast, like Slurm's ``afterok``).
         job_name: name used for logging and as a Job label (default ``"data_processing"``).
 
     Example:
@@ -139,6 +141,7 @@ class JobsPipelineExecutor(PipelineExecutor):
         secrets: dict[str, Any] | None = None,
         max_retries: int = 1,
         poll_interval: int = 15,
+        run_on_dependency_fail: bool = False,
         job_name: str = "data_processing",
     ):
         super().__init__(pipeline, logging_dir, skip_completed, randomize_start_duration)
@@ -163,6 +166,7 @@ class JobsPipelineExecutor(PipelineExecutor):
         self.secrets = secrets
         self.max_retries = max_retries
         self.poll_interval = poll_interval
+        self.run_on_dependency_fail = run_on_dependency_fail
         self.job_name = job_name
         self._launched = False
 
@@ -200,12 +204,35 @@ class JobsPipelineExecutor(PipelineExecutor):
             "depends= must be a JobsPipelineExecutor"
         )
         if self.depends:
-            # launch any unlaunched dependency, then poll its completions until it is done
-            if not self.depends._launched:
+            # launch any unlaunched dependency, then wait for its completions
+            depends_launched_here = not self.depends._launched
+            if depends_launched_here:
                 logger.info(f'Launching dependency job "{self.depends.job_name}"')
                 self.depends.launch_job()
-            while (incomplete := len(self.depends.get_incomplete_ranks(skip_completed=True))) > 0:
-                logger.info(f"Dependency job still has {incomplete}/{self.depends.world_size} tasks. Waiting...")
+            while True:
+                # completions/ is written by the remote Jobs, so drop the launcher's cached directory
+                # listing before checking — a long-lived HfFileSystem otherwise keeps serving a stale
+                # (pre-completion) listing and we would never see the Jobs finish.
+                self.depends.logging_dir.fs.invalidate_cache()
+                incomplete = self.depends.get_incomplete_ranks(skip_completed=True)
+                if not incomplete:
+                    break
+                if depends_launched_here:
+                    # launch_job() blocks, so the dependency has finished; any ranks still incomplete have
+                    # failed (retries exhausted). Don't wait forever.
+                    if self.run_on_dependency_fail:
+                        logger.warning(
+                            f"Dependency '{self.depends.job_name}' finished with {len(incomplete)} failed "
+                            f"task(s); continuing anyway (run_on_dependency_fail=True)."
+                        )
+                        break
+                    raise RuntimeError(
+                        f"Dependency job '{self.depends.job_name}' finished with {len(incomplete)}/"
+                        f"{self.depends.world_size} tasks still incomplete. Rerun to resume, raise max_retries, "
+                        f"or set run_on_dependency_fail=True to continue anyway."
+                    )
+                # dependency was launched by another process and is still running — keep waiting
+                logger.info(f"Dependency job still has {len(incomplete)}/{self.depends.world_size} tasks. Waiting...")
                 time.sleep(2 * 60)
             self.depends = None  # avoid pickling the dependency chain
 
@@ -319,6 +346,8 @@ class JobsPipelineExecutor(PipelineExecutor):
 
     def _merge_stats(self):
         """Merge per-rank stats into ``stats.json`` once every task is complete."""
+        # the Jobs wrote completions/ + stats/ remotely; refresh the launcher's cached listing first
+        self.logging_dir.fs.invalidate_cache()
         incomplete = self.get_incomplete_ranks(range(self.world_size))
         if incomplete:
             logger.warning(

--- a/src/datatrove/executor/jobs.py
+++ b/src/datatrove/executor/jobs.py
@@ -30,6 +30,9 @@ _SUCCESS_JOB_STAGE = "COMPLETED"
 class JobsPipelineExecutor(PipelineExecutor):
     """Execute a pipeline on Hugging Face Jobs.
 
+    **Experimental**: this executor is experimental and its API may change (or break) in
+    future releases without the usual deprecation cycle.
+
     Fans a datatrove pipeline out across a pool of Hugging Face Jobs, mirroring
     :class:`~datatrove.executor.slurm.SlurmPipelineExecutor` but launching Jobs with
     ``huggingface_hub.run_uv_job`` instead of calling ``sbatch``.
@@ -144,6 +147,7 @@ class JobsPipelineExecutor(PipelineExecutor):
         run_on_dependency_fail: bool = False,
         job_name: str = "data_processing",
     ):
+        logger.warning("JobsPipelineExecutor is experimental: its API may change (or break) in future releases.")
         super().__init__(pipeline, logging_dir, skip_completed, randomize_start_duration)
         if self.logging_dir.is_local():
             raise ValueError(

--- a/src/datatrove/executor/jobs.py
+++ b/src/datatrove/executor/jobs.py
@@ -253,6 +253,10 @@ class JobsPipelineExecutor(PipelineExecutor):
             self.depends = None  # avoid pickling the dependency chain
 
         self._ensure_logging_dir_repo()
+        # completions/ may have been written remotely since this fs instance last listed it (shared
+        # fsspec instances, same-process reruns) — refresh before deciding what to (re)launch, as the
+        # depends-wait loop and _merge_stats already do.
+        self.logging_dir.fs.invalidate_cache()
         ranks_to_run = self.get_incomplete_ranks()
         if len(ranks_to_run) == 0:
             logger.info(f"Skipping launch of {self.job_name} as all {self.tasks} tasks have already been completed.")

--- a/tests/executor/test_jobs.py
+++ b/tests/executor/test_jobs.py
@@ -255,6 +255,52 @@ class TestJobsExecutor(unittest.TestCase):
             second.run()
         self.assertEqual(len(launched_second), 0)
 
+    def test_failed_jobs_resubmitted_up_to_max_retries(self):
+        """A crashed index is resubmitted and completes on retry; one that keeps crashing is given up on."""
+        log_dir = get_datafolder("memory://jobs-test/retries")
+        executor = JobsPipelineExecutor(
+            pipeline=[_EmitBlock()], tasks=3, logging_dir=log_dir, token="t", poll_interval=0, max_retries=1
+        )
+        attempts: dict[str, int] = {}
+        job_stages: dict[str, str] = {}
+
+        def fake_run(script, *, script_args=None, env=None, **kwargs):
+            idx = env[ARRAY_INDEX_ENV_VAR]
+            attempts[idx] = attempts.get(idx, 0) + 1
+            job = MagicMock()
+            job.id = f"job-{idx}-attempt{attempts[idx]}"
+            # index 1 crashes on its first attempt only; index 2 crashes every time
+            if (idx == "1" and attempts[idx] == 1) or idx == "2":
+                job_stages[job.id] = "ERROR"  # died before running any rank
+                return job
+            with executor.logging_dir.open("executor.pik", "rb") as f:
+                worker = dill.load(f)
+            prev = os.environ.get(ARRAY_INDEX_ENV_VAR)
+            os.environ[ARRAY_INDEX_ENV_VAR] = idx
+            try:
+                worker.run()
+            finally:
+                if prev is None:
+                    os.environ.pop(ARRAY_INDEX_ENV_VAR, None)
+                else:
+                    os.environ[ARRAY_INDEX_ENV_VAR] = prev
+            job_stages[job.id] = "COMPLETED"
+            return job
+
+        def fake_inspect(*, job_id, **kwargs):
+            job = MagicMock()
+            job.status.stage = job_stages[job_id]
+            return job
+
+        with patch("huggingface_hub.run_uv_job", fake_run), patch("huggingface_hub.inspect_job", fake_inspect):
+            executor.run()
+
+        self.assertEqual(attempts, {"0": 1, "1": 2, "2": 2})  # one resubmit each for 1 and 2, then give up on 2
+        self.assertTrue(log_dir.isfile("completions/00000"))
+        self.assertTrue(log_dir.isfile("completions/00001"))  # completed on the resubmit
+        self.assertFalse(log_dir.isfile("completions/00002"))  # retries exhausted -> left incomplete
+        self.assertFalse(log_dir.isfile("stats.json"))  # an incomplete run must not merge stats
+
     def test_depends_runs_parent_then_child(self):
         """`depends=` launches the parent to completion, then runs the child; both write full layouts."""
         parent_dir = get_datafolder("memory://jobs-test/dep-parent")

--- a/tests/executor/test_jobs.py
+++ b/tests/executor/test_jobs.py
@@ -1,0 +1,124 @@
+import math
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+import dill
+
+from datatrove.executor.jobs import ARRAY_INDEX_ENV_VAR, JobsPipelineExecutor
+from datatrove.io import get_datafolder
+from datatrove.pipeline.base import PipelineStep
+
+
+class _EmitBlock(PipelineStep):
+    """Trivial pipeline step so each rank has something to process (mirrors test_ray's SleepBlock)."""
+
+    name = "emit"
+    type = "test"
+
+    def run(self, data, rank=None, world_size=None):
+        for i in range(5):
+            yield i
+
+
+def _make_fake_jobs(executor: JobsPipelineExecutor):
+    """Build patched ``run_uv_job`` / ``inspect_job`` that run each array index in-process.
+
+    ``run_uv_job`` is patched to do exactly what a real Job does: set ``DATATROVE_JOB_ARRAY_INDEX``,
+    rehydrate the pickled executor from the shared ``logging_dir`` (exercising the real dill round-trip),
+    and call ``run()`` so the worker path executes its block of ranks. ``inspect_job`` always reports
+    ``COMPLETED`` since the work already ran synchronously.
+    """
+    launched: dict[str, str] = {}
+
+    def fake_run_uv_job(script, *, script_args=None, env=None, **kwargs):
+        array_index = env[ARRAY_INDEX_ENV_VAR]
+        with executor.logging_dir.open("executor.pik", "rb") as f:
+            worker = dill.load(f)
+        prev = os.environ.get(ARRAY_INDEX_ENV_VAR)
+        os.environ[ARRAY_INDEX_ENV_VAR] = array_index
+        try:
+            worker.run()
+        finally:
+            if prev is None:
+                os.environ.pop(ARRAY_INDEX_ENV_VAR, None)
+            else:
+                os.environ[ARRAY_INDEX_ENV_VAR] = prev
+        job = MagicMock()
+        job.id = f"job-{array_index}"
+        job.url = f"https://hf.co/jobs/job-{array_index}"
+        launched[job.id] = array_index
+        return job
+
+    def fake_inspect_job(*, job_id, **kwargs):
+        job = MagicMock()
+        job.status.stage = "COMPLETED"
+        return job
+
+    return fake_run_uv_job, fake_inspect_job, launched
+
+
+class TestJobsExecutor(unittest.TestCase):
+    def test_local_logging_dir_rejected(self):
+        """A local logging_dir cannot be shared with remote Jobs, so it must raise."""
+        with self.assertRaises(ValueError):
+            JobsPipelineExecutor(pipeline=[_EmitBlock()], tasks=2, logging_dir="/tmp/datatrove-jobs-local")
+
+    def test_fan_out_writes_full_layout(self):
+        """Fanning out over N array indices writes the standard datatrove file layout for every rank."""
+        for tasks, tasks_per_job, workers in ((6, 2, 2), (3, 1, -1)):
+            log_dir = get_datafolder(f"memory://jobs-test/{tasks}-{tasks_per_job}-{workers}")
+            executor = JobsPipelineExecutor(
+                pipeline=[_EmitBlock()],
+                tasks=tasks,
+                tasks_per_job=tasks_per_job,
+                workers=workers,
+                logging_dir=log_dir,
+                token="hf_faketoken",
+                poll_interval=0,
+            )
+            fake_run, fake_inspect, launched = _make_fake_jobs(executor)
+            with (
+                patch("huggingface_hub.run_uv_job", fake_run),
+                patch("huggingface_hub.inspect_job", fake_inspect),
+            ):
+                executor.run()
+
+            self.assertEqual(len(launched), math.ceil(tasks / tasks_per_job))
+            file_list = ["executor.json", "stats.json"] + [
+                x
+                for rank in range(tasks)
+                for x in (f"completions/{rank:05d}", f"logs/task_{rank:05d}.log", f"stats/{rank:05d}.json")
+            ]
+            for file in file_list:
+                self.assertTrue(log_dir.isfile(file), f"Expected file {file} not found in {log_dir}")
+
+    def test_resume_skips_completed_ranks(self):
+        """A second run over an already-completed logging_dir launches no Jobs (idempotent resume)."""
+        log_dir = get_datafolder("memory://jobs-test/resume")
+
+        def build():
+            return JobsPipelineExecutor(
+                pipeline=[_EmitBlock()],
+                tasks=4,
+                tasks_per_job=1,
+                logging_dir=log_dir,
+                token="hf_faketoken",
+                poll_interval=0,
+            )
+
+        first = build()
+        fr, fi, launched_first = _make_fake_jobs(first)
+        with patch("huggingface_hub.run_uv_job", fr), patch("huggingface_hub.inspect_job", fi):
+            first.run()
+        self.assertEqual(len(launched_first), 4)
+
+        second = build()
+        fr2, fi2, launched_second = _make_fake_jobs(second)
+        with patch("huggingface_hub.run_uv_job", fr2), patch("huggingface_hub.inspect_job", fi2):
+            second.run()
+        self.assertEqual(len(launched_second), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/executor/test_jobs.py
+++ b/tests/executor/test_jobs.py
@@ -157,6 +157,78 @@ class TestJobsExecutor(unittest.TestCase):
                     f"rank {rank} stats leaked across ranks (expected {EMITTED_PER_RANK}, got {emitted})",
                 )
 
+    def test_invalid_workers_and_tasks_per_job_rejected(self):
+        """Nonsensical concurrency settings fail loudly instead of silently launching nothing."""
+        log_dir = get_datafolder("memory://jobs-test/validation")
+        for kwargs in ({"tasks_per_job": 0}, {"tasks_per_job": -2}, {"workers": 0}, {"workers": -3}):
+            with self.assertRaises(ValueError):
+                JobsPipelineExecutor(pipeline=[_EmitBlock()], tasks=2, logging_dir=log_dir, **kwargs)
+
+    def test_credentials_not_persisted_to_logging_dir(self):
+        """token= and secrets= must never end up in executor.pik / executor.json on the shared logging_dir."""
+        log_dir = get_datafolder("memory://jobs-test/credentials")
+        executor = JobsPipelineExecutor(
+            pipeline=[_EmitBlock()],
+            tasks=2,
+            logging_dir=log_dir,
+            token="hf_faketoken",
+            secrets={"MY_SECRET": "sekritvalue"},
+            poll_interval=0,
+        )
+        fake_run, fake_inspect, launched = _make_fake_jobs(executor)
+        with patch("huggingface_hub.run_uv_job", fake_run), patch("huggingface_hub.inspect_job", fake_inspect):
+            executor.run()
+
+        self.assertEqual(len(launched), 2)  # the scrubbed pickle must still run fine worker-side
+        with log_dir.open("executor.pik", "rb") as f:
+            pik = f.read()
+        with log_dir.open("executor.json", "r") as f:
+            as_json = f.read()
+        for credential in (b"hf_faketoken", b"sekritvalue"):
+            self.assertNotIn(credential, pik)
+            self.assertNotIn(credential.decode(), as_json)
+        # scrubbing must not clobber the live executor's own credentials
+        self.assertEqual(executor.token, "hf_faketoken")
+        self.assertEqual(executor.secrets, {"MY_SECRET": "sekritvalue"})
+
+    def test_stats_merged_with_skip_completed_false(self):
+        """skip_completed=False disables skipping, but the final stats merge must still happen."""
+        log_dir = get_datafolder("memory://jobs-test/no-skip")
+        executor = JobsPipelineExecutor(
+            pipeline=[_EmitBlock()],
+            tasks=2,
+            logging_dir=log_dir,
+            token="hf_faketoken",
+            poll_interval=0,
+            skip_completed=False,
+        )
+        fake_run, fake_inspect, _ = _make_fake_jobs(executor)
+        with patch("huggingface_hub.run_uv_job", fake_run), patch("huggingface_hub.inspect_job", fake_inspect):
+            executor.run()
+        self.assertTrue(log_dir.isfile("stats.json"))
+
+    def test_rerun_merges_stats_if_missing(self):
+        """A rerun over a fully-completed dir recreates stats.json if the first coordinator died pre-merge."""
+        log_dir = get_datafolder("memory://jobs-test/stats-rerun")
+
+        def build():
+            return JobsPipelineExecutor(
+                pipeline=[_EmitBlock()], tasks=2, logging_dir=log_dir, token="hf_faketoken", poll_interval=0
+            )
+
+        first = build()
+        fr, fi, _ = _make_fake_jobs(first)
+        with patch("huggingface_hub.run_uv_job", fr), patch("huggingface_hub.inspect_job", fi):
+            first.run()
+        log_dir.rm("stats.json")  # simulate a coordinator killed after the last rank but before the merge
+
+        second = build()
+        fr2, fi2, launched = _make_fake_jobs(second)
+        with patch("huggingface_hub.run_uv_job", fr2), patch("huggingface_hub.inspect_job", fi2):
+            second.run()
+        self.assertEqual(len(launched), 0)
+        self.assertTrue(log_dir.isfile("stats.json"))
+
     def test_resume_skips_completed_ranks(self):
         """A second run over an already-completed logging_dir launches no Jobs (idempotent resume)."""
         log_dir = get_datafolder("memory://jobs-test/resume")

--- a/tests/executor/test_jobs.py
+++ b/tests/executor/test_jobs.py
@@ -157,6 +157,57 @@ class TestJobsExecutor(unittest.TestCase):
                     f"rank {rank} stats leaked across ranks (expected {EMITTED_PER_RANK}, got {emitted})",
                 )
 
+    def test_hf_logging_repo_auto_created(self):
+        """An hf:// logging repo/bucket that doesn't exist yet is created before the first listing."""
+        cases = [
+            (
+                "hf://datasets/some_user/some-logs/subdir",
+                "create_repo",
+                "some_user/some-logs",
+                {"repo_type": "dataset"},
+            ),
+            (
+                "hf://datasets/some_user/some-logs@refs%2Fconvert%2Fparquet",
+                "create_repo",
+                "some_user/some-logs",
+                {"repo_type": "dataset"},
+            ),
+            ("hf://spaces/some_user/some-space/logs", "create_repo", "some_user/some-space", {"repo_type": "space"}),
+            (
+                "hf://some_user/some-model-logs/subdir",
+                "create_repo",
+                "some_user/some-model-logs",
+                {"repo_type": "model"},
+            ),
+            ("hf://buckets/some_user/some-bucket/logs", "create_bucket", "some_user/some-bucket", {}),
+        ]
+        for path, expected_fn, expected_id, extra_kwargs in cases:
+            executor = JobsPipelineExecutor(pipeline=[_EmitBlock()], tasks=2, logging_dir=path, token="hf_faketoken")
+            with (
+                patch("huggingface_hub.create_repo") as create_repo,
+                patch("huggingface_hub.create_bucket") as create_bucket,
+            ):
+                executor._ensure_logging_dir_repo()
+            called = {"create_repo": create_repo, "create_bucket": create_bucket}[expected_fn]
+            not_called = create_bucket if expected_fn == "create_repo" else create_repo
+            called.assert_called_once_with(
+                expected_id, private=True, exist_ok=True, token="hf_faketoken", **extra_kwargs
+            )
+            not_called.assert_not_called()
+
+    def test_non_hf_logging_dir_not_auto_created(self):
+        """Auto-creation is hf://-only: other remote filesystems are left untouched."""
+        executor = JobsPipelineExecutor(
+            pipeline=[_EmitBlock()], tasks=2, logging_dir=get_datafolder("memory://jobs-test/no-create"), token="t"
+        )
+        with (
+            patch("huggingface_hub.create_repo") as create_repo,
+            patch("huggingface_hub.create_bucket") as create_bucket,
+        ):
+            executor._ensure_logging_dir_repo()
+        create_repo.assert_not_called()
+        create_bucket.assert_not_called()
+
     def test_invalid_workers_and_tasks_per_job_rejected(self):
         """Nonsensical concurrency settings fail loudly instead of silently launching nothing."""
         log_dir = get_datafolder("memory://jobs-test/validation")

--- a/tests/executor/test_jobs.py
+++ b/tests/executor/test_jobs.py
@@ -1,3 +1,4 @@
+import json
 import math
 import os
 import unittest
@@ -10,6 +11,9 @@ from datatrove.io import get_datafolder
 from datatrove.pipeline.base import PipelineStep
 
 
+EMITTED_PER_RANK = 5
+
+
 class _EmitBlock(PipelineStep):
     """Trivial pipeline step so each rank has something to process (mirrors test_ray's SleepBlock)."""
 
@@ -17,8 +21,27 @@ class _EmitBlock(PipelineStep):
     type = "test"
 
     def run(self, data, rank=None, world_size=None):
-        for i in range(5):
+        for i in range(EMITTED_PER_RANK):
+            self.stat_update("emitted")
             yield i
+
+
+def _stat_totals(stats_json, name):
+    """Collect every numeric total recorded under ``name`` anywhere in a serialized PipelineStats."""
+    found = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key == name:
+                    found.append(value["total"] if isinstance(value, dict) and "total" in value else value)
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(stats_json)
+    return found
 
 
 def _make_fake_jobs(executor: JobsPipelineExecutor):
@@ -92,6 +115,16 @@ class TestJobsExecutor(unittest.TestCase):
             ]
             for file in file_list:
                 self.assertTrue(log_dir.isfile(file), f"Expected file {file} not found in {log_dir}")
+
+            # per-rank stats must reflect only that rank's work, even when tasks_per_job > 1 packs
+            # several ranks into one worker process (guards the per-rank pipeline deepcopy).
+            for rank in range(tasks):
+                with log_dir.open(f"stats/{rank:05d}.json", "r") as f:
+                    emitted = _stat_totals(json.load(f), "emitted")
+                self.assertTrue(
+                    emitted and all(e == EMITTED_PER_RANK for e in emitted),
+                    f"rank {rank} stats leaked across ranks (expected {EMITTED_PER_RANK}, got {emitted})",
+                )
 
     def test_resume_skips_completed_ranks(self):
         """A second run over an already-completed logging_dir launches no Jobs (idempotent resume)."""

--- a/tests/executor/test_jobs.py
+++ b/tests/executor/test_jobs.py
@@ -81,6 +81,37 @@ def _make_fake_jobs(executor: JobsPipelineExecutor):
     return fake_run_uv_job, fake_inspect_job, launched
 
 
+def _make_depends_fake():
+    """A run_uv_job/inspect_job pair that works across a depends= chain (loads each stage's pik from args)."""
+    import fsspec
+
+    launched = []
+
+    def fake_run_uv_job(script, *, script_args=None, env=None, **kwargs):
+        with fsspec.open(script_args[0], "rb") as f:  # the pik path (resolve_paths keeps the scheme)
+            worker = dill.load(f)
+        prev = os.environ.get(ARRAY_INDEX_ENV_VAR)
+        os.environ[ARRAY_INDEX_ENV_VAR] = env[ARRAY_INDEX_ENV_VAR]
+        try:
+            worker.run()
+        finally:
+            if prev is None:
+                os.environ.pop(ARRAY_INDEX_ENV_VAR, None)
+            else:
+                os.environ[ARRAY_INDEX_ENV_VAR] = prev
+        job = MagicMock()
+        job.id = f"job-{len(launched)}"
+        launched.append(env[ARRAY_INDEX_ENV_VAR])
+        return job
+
+    def fake_inspect_job(*, job_id, **kwargs):
+        job = MagicMock()
+        job.status.stage = "COMPLETED"
+        return job
+
+    return fake_run_uv_job, fake_inspect_job, launched
+
+
 class TestJobsExecutor(unittest.TestCase):
     def test_local_logging_dir_rejected(self):
         """A local logging_dir cannot be shared with remote Jobs, so it must raise."""
@@ -151,6 +182,48 @@ class TestJobsExecutor(unittest.TestCase):
         with patch("huggingface_hub.run_uv_job", fr2), patch("huggingface_hub.inspect_job", fi2):
             second.run()
         self.assertEqual(len(launched_second), 0)
+
+    def test_depends_runs_parent_then_child(self):
+        """`depends=` launches the parent to completion, then runs the child; both write full layouts."""
+        parent_dir = get_datafolder("memory://jobs-test/dep-parent")
+        child_dir = get_datafolder("memory://jobs-test/dep-child")
+        parent = JobsPipelineExecutor(
+            pipeline=[_EmitBlock()], tasks=2, logging_dir=parent_dir, token="t", poll_interval=0
+        )
+        child = JobsPipelineExecutor(
+            pipeline=[_EmitBlock()], tasks=2, logging_dir=child_dir, token="t", poll_interval=0, depends=parent
+        )
+        fr, fi, launched = _make_depends_fake()
+        with patch("huggingface_hub.run_uv_job", fr), patch("huggingface_hub.inspect_job", fi):
+            child.run()
+        self.assertEqual(len(launched), 4)  # 2 parent + 2 child array indices
+        for log_dir in (parent_dir, child_dir):
+            self.assertEqual(len(log_dir.list_files("completions")), 2)
+
+    def test_depends_fails_fast_when_dependency_incomplete(self):
+        """If the dependency finishes with failed tasks, the child raises instead of waiting forever."""
+        parent_dir = get_datafolder("memory://jobs-test/dep-fail-parent")
+        child_dir = get_datafolder("memory://jobs-test/dep-fail-child")
+        parent = JobsPipelineExecutor(
+            pipeline=[_EmitBlock()], tasks=2, logging_dir=parent_dir, token="t", poll_interval=0, max_retries=0
+        )
+        child = JobsPipelineExecutor(
+            pipeline=[_EmitBlock()], tasks=2, logging_dir=child_dir, token="t", poll_interval=0, depends=parent
+        )
+
+        def failing_run(script, *, script_args=None, env=None, **kwargs):
+            job = MagicMock()  # never runs the ranks -> no completions written
+            job.id = "failing"
+            return job
+
+        def error_inspect(*, job_id, **kwargs):
+            job = MagicMock()
+            job.status.stage = "ERROR"
+            return job
+
+        with patch("huggingface_hub.run_uv_job", failing_run), patch("huggingface_hub.inspect_job", error_inspect):
+            with self.assertRaises(RuntimeError):
+                child.run()
 
 
 if __name__ == "__main__":

--- a/tests/executor/test_jobs.py
+++ b/tests/executor/test_jobs.py
@@ -301,6 +301,42 @@ class TestJobsExecutor(unittest.TestCase):
         self.assertFalse(log_dir.isfile("completions/00002"))  # retries exhausted -> left incomplete
         self.assertFalse(log_dir.isfile("stats.json"))  # an incomplete run must not merge stats
 
+    def test_failed_rerun_does_not_merge_stale_stats(self):
+        """A skip_completed=False rerun whose ranks all fail must not rebuild stats.json from stale markers."""
+        log_dir = get_datafolder("memory://jobs-test/stale-stats")
+
+        first = JobsPipelineExecutor(pipeline=[_EmitBlock()], tasks=2, logging_dir=log_dir, token="t", poll_interval=0)
+        fr, fi, _ = _make_fake_jobs(first)
+        with patch("huggingface_hub.run_uv_job", fr), patch("huggingface_hub.inspect_job", fi):
+            first.run()
+        self.assertTrue(log_dir.isfile("stats.json"))
+        log_dir.rm("stats.json")
+
+        second = JobsPipelineExecutor(
+            pipeline=[_EmitBlock()],
+            tasks=2,
+            logging_dir=log_dir,
+            token="t",
+            poll_interval=0,
+            skip_completed=False,
+            max_retries=0,
+        )
+
+        def failing_run(script, *, script_args=None, env=None, **kwargs):
+            job = MagicMock()  # dies before running any rank
+            job.id = f"failing-{env[ARRAY_INDEX_ENV_VAR]}"
+            return job
+
+        def error_inspect(*, job_id, **kwargs):
+            job = MagicMock()
+            job.status.stage = "ERROR"
+            return job
+
+        with patch("huggingface_hub.run_uv_job", failing_run), patch("huggingface_hub.inspect_job", error_inspect):
+            second.run()
+        # run 1's completion markers would mask run 2's failures — the merge must not run at all
+        self.assertFalse(log_dir.isfile("stats.json"))
+
     def test_depends_runs_parent_then_child(self):
         """`depends=` launches the parent to completion, then runs the child; both write full layouts."""
         parent_dir = get_datafolder("memory://jobs-test/dep-parent")


### PR DESCRIPTION
**Framing.** Started as a draft proposal; after discussion (thanks @lvwerra, @guipenedo) this is now intended to land as an **explicitly experimental** feature: the executor warns on init, the docstrings say the API may change or break, and none of the core datatrove logic is touched (the diff is additive: one new executor + examples + tests). Claude Code did most of the heavy lifting after discussing the design with me.

### Review round (July 10–14)
Independently verified by @JoelNiklaus (all three examples as real Jobs + the unit suite). All feedback addressed: auto-create of the `hf://` logging repo/bucket (ea0661d, with tests), examples' `DEPENDENCIES` literally install from git + minhash example defaults to a Storage Bucket (18ae3f4), fs-cache refresh on the launch path (9f41882, via Bugbot). **Until this ships in a release, install with:** `datatrove[io,processing] @ git+https://github.com/huggingface/datatrove`.

### What's here
- `JobsPipelineExecutor(PipelineExecutor)` in `executor/jobs.py` — mirrors `SlurmPipelineExecutor` but launches Jobs via `huggingface_hub.run_uv_job` instead of `sbatch`.
- 3 adapted examples (`filter_hf_dataset_jobs.py`, `tokenize_hf_dataset_jobs.py`, `minhash_deduplication_jobs.py`) + unit tests (mock the Jobs API, `memory://` logging_dir).

### Review pass before undrafting (July 9)
Two independent reviews of the full diff (Codex + Claude), fixes applied for everything high-confidence, each pinned by a new test that fails on the previous code:
- **Credential scrub (the important one):** `token=` / `secrets=` passed to the executor were dill-pickled into `executor.pik` and serialized into `executor.json` on the shared (possibly public) `logging_dir`. They are now scrubbed before anything is persisted — Jobs receive credentials exclusively as Job secrets.
- Stats: `stats.json` is now merged when `skip_completed=False`, and re-merged on rerun if a previous coordinator died after the last rank completed but before the merge.
- `tasks_per_job` / `workers` are validated (`workers=0` used to silently launch nothing; `tasks_per_job=0` was a raw `ZeroDivisionError`).
- `randomize_start_duration` was documented but dropped by the `_run_for_rank` override — now honored (mirrors the base executor).
- Docstring: cancel stale Jobs from a previous launch before rerunning (each launch rewrites `executor.pik` / `ranks_to_run.json`).

### Verified on real Jobs (July 9, this branch)
- Full CI-equivalent test suite (`uv sync --extra testing` + `pytest ./tests/`) run in a cpu-upgrade Job: **381 passed, 4 skipped** (test_ray excluded — Ray segfaults in Job containers regardless of this branch; covered by GitHub CI).
- Single-stage fan-out (filter example): 4 Jobs, 100k docs read, filtered output written, stats merged; experimental warning is the first coordinator line.
- 4-stage minhash `depends=` chain at realistic scale (ag_news, 120k docs, 24 signature tasks). Two findings on `hf://` *dataset repos* as the shared store: (1) at 8 concurrent Jobs committing signature files to one repo, 6/24 ranks exhausted retries on Hub commit rate limits (429 "maximum time in concurrency queue reached") — the chain **failed fast with resume guidance as designed**, and rerunning at `workers=4` resumed exactly the 6 failed ranks and completed stage 1; (2) stage-2 bucket-merge tasks (a 24-way priority-queue merge over remote signature files, i.e. many tiny ranged reads) run ~45 min each over a dataset repo — slow but correct, and fixed by `lines_to_buffer=-1` (see the follow-up comment: 65 min → 99 s). The full 4-stage chain completed end-to-end: 120,000 docs in → 115,736 kept, 4,264 near-duplicates removed.
- **Buckets answer the consistency question (Q4) — for writes:** the same signature stage on a Storage Bucket (`hf://buckets/...`, same HfFileSystem code path, no code changes, needs huggingface_hub>=1.6.0) passed **24/24 at `workers=8` with zero retries** — no commit queue, no read-after-write lag. Caveat from the same runs: buckets do **not** rescue the merge stage — stage-2 tasks take ~45 min (repo) vs ~30 min (bucket) per task, the same order of magnitude, because the dominant cost is thousands of tiny ranged reads through `HfFileSystem` (Slurm avoids this with node-local disk; a fix would be read buffering/local staging, not a store choice). Both findings are documented in the minhash example.
- Version floor sanity check: `run_uv_job`/`inspect_job` import cleanly at exactly `huggingface-hub==1.5.0` (the current pin); `hf://buckets` paths need >=1.6.0 (noted in the docstring).
- Failure semantics for real: a stage with deterministically-failing ranks exhausts `max_retries` (resubmit observed), the dependent stage fails fast with `RuntimeError` (`run_on_dependency_fail=False`); rerunning with a fixed pipeline relaunched **only** the 4 previously-failed ranks (idempotent resume), after which the child ran clean.
- 2-stage tokenize→merge (16 fan-out tasks + 1 fan-in task): completed, stats merged for both stages.
- Credential scrub verified against a real `hf://` logging repo: ran with an explicit `token=` + canary secret; neither is present in the persisted `executor.pik` / `executor.json`, and the Jobs still authenticate (via Job secrets).

### Known limitations (accepted for an experimental first cut)
- `run()` does not raise when ranks remain permanently failed after retries — it logs and leaves the completion markers for an idempotent rerun (fire-and-forget-ish, like Slurm). A dependent stage *does* fail fast. Open question whether `run()` itself should raise.
- A child whose `depends=` parent was run in a *different* process and left permanently incomplete keeps waiting (2-min polls) — cross-process, markers alone can't distinguish "still running" from "failed for good".
- Coordinator calls to `run_uv_job` / `inspect_job` have no retry/backoff — a transient API error kills the coordinator (in-flight Jobs finish; rerun resumes).
- `timeout=None` (default) has no coordinator-side deadline for a Job wedged in a non-terminal state; set `timeout=` for an upper bound.

### How it works (the Slurm→Jobs mapping)
Reuses the Slurm machinery unchanged — dill-pickle the executor to `logging_dir/executor.pik`, write `ranks_to_run.json`, reuse the existing `launch_pickled_pipeline` worker. Three swaps: (1) `SLURM_ARRAY_TASK_ID` → `DATATROVE_JOB_ARRAY_INDEX`; (2) `sbatch --array 0-M%W` → K `run_uv_job` calls throttled by a local polling loop; (3) `--dependency=afterok` → poll `completions/`. Same `executor.json`/`completions/` layout, so `jobs_status`/`track_jobs` work unchanged.

### Open design questions (for post-merge iteration)

1. **Coordination model.** The launcher currently runs *locally* and blocks for the whole run — it submits Jobs, polls to honor `workers`, and merges stats (like Local/Ray; only Slurm is fire-and-forget). Is that the model you want, or should the canonical path be a **coordinator Job** (runs the launcher itself so nothing stays on the client), or built on **`SandboxPool`** (packs workers onto warm host VMs)?
   *Lean: the local launcher is the simplest first cut (what's here); a coordinator Job is the obvious way to free the client; `SandboxPool` is the interesting option for many tiny tasks (CPU-only, bigger change). The "don't launch Jobs from within a Job" note is about the worker path — a dedicated coordinator Job is a separate role.*

2. **Worker entrypoint / getting datatrove onto the worker.** Current: `run_uv_job` uploads `launch_pickled_pipeline` and installs datatrove into a fresh `uv` env via `dependencies` — a ~30–90s cold install per Job (worse with spacy/torch). But Jobs accept an arbitrary image (`run_job(image=…)` takes a Docker ref, or even an `hf.co/spaces/…` image), so the entrypoint can work several ways: uv-install-per-job (current), a prebuilt / uv-baked datatrove image (warm start), or a Space-as-image. Which do you want as the default — and is a maintained datatrove base image something you'd want to own?
   *Lean: uv-install is a fine default (nothing to maintain; the install is noise against a real job's runtime); an optional `image=` gives the warm-start path (prebuilt / uv-baked / Space). A blessed base image only if you'd want to own it. Observed today: total per-Job overhead (scheduling + uv env build with `datatrove[io,processing]`) is ~1–2 min on cpu-basic — so size tasks to at least several minutes of work each.*

3. **Dependency declaration.** Users must currently list every extra their steps need, and it's non-obvious (even `LambdaFilter` needs `[processing]` because `datatrove.pipeline.filters` hard-imports `regex`; minhash needs bare `spacy`). Leave it manual, or infer from steps' `_requires_dependencies`? (Inference catches `spacy` but *not* `regex` — the latter is a module-level import, not a declared dep.) Related: datatrove version pinning for pickle-compat is currently the user's responsibility via the dep string — should the executor pin it?

4. **Store & consistency.** `logging_dir` must be remote. On `hf://` we hit real issues — read-after-write 404s between stages and client-side listing-cache staleness (see Issues); patched enough to work (retries + cache invalidation) but rough. A strongly-consistent store — e.g. HF's **S3-compatible buckets** (closer to how datatrove already uses `s3://`) — would likely be a cleaner fit than `hf://` for multi-stage chains. Open question, not something we've solved.

5. **`depends=` semantics.** Chaining is blocking recursion (launch parent → block → run child). We added fail-fast on a permanently-failed dependency + a `run_on_dependency_fail` flag (mirrors `afterok`/`afterany`). Is that the semantics you want, or do you want a real DAG/scheduler rather than nested blocking launches?

6. **Concurrency semantics of `workers`.** It's a local cap enforced by polling `inspect_job` (no native Jobs array/`%W`). On failure we resubmit up to `max_retries`. Right knobs/defaults?

7. **Scope.** Kept text-only (matches the rest of datatrove). Design the worker contract with media in mind now, or defer?

### Issues hit (and what we did)
- **Per-rank stat inflation** when `tasks_per_job>1` — ranks shared pipeline-step objects, so stats accumulated. Deepcopy the pipeline per rank (note: `slurm.py` has this latent too — data was always fine, only stats over-counted).
- **`depends=` hung forever** — the launcher's `HfFileSystem` cached `completions/` and never refreshed, so it couldn't see completions the *remote Jobs* wrote (fresh process saw 14/14; launcher saw 13/14). Fixed with `invalidate_cache()` before each poll + stats merge. This is the one that would bite anyone using `depends=` on `hf://`.
- **Infinite wait on a failed dependency** — poll loop waited forever; added fail-fast + opt-out.
- **`hf://` read-after-write 404** between stages — `max_retries≥1` covers it (see Q4).
- **Dependency gotchas** — `[processing]` for filters (`regex`), bare `spacy` for the English tokenizer (only shipped in the heavy `multilingual` extra).
- **uv cold-install per Job** — perf cost, see Q2.

### Alternative paths considered / not taken
- **Pickle a stock `LocalPipelineExecutor` instead of `self`** → workers could run stock PyPI datatrove (no fork install). Rejected for Slurm-symmetry, but a real option if you'd rather not require datatrove-on-the-worker to match.
- **`run_job` + prebuilt/uv-baked image** instead of `run_uv_job` (Q2).
- **`SandboxPool` backend** — CPU-only, but amortizes install across a warm host pool; likely the better long-term shape for many small tasks (Q1).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New distributed execution path touches remote storage coordination, credential handling, and multi-stage `depends=` semantics; core pipeline code is unchanged but misconfigured `logging_dir`/deps or stale Jobs could cause failed or partial runs.
> 
> **Overview**
> Adds an **experimental** `JobsPipelineExecutor` so datatrove pipelines can run on [Hugging Face Jobs](https://huggingface.co/docs/huggingface_hub/en/guides/jobs) with the same coordination model as Slurm: pickle the executor to a shared remote `logging_dir`, shard work via `ranks_to_run.json` and `completions/`, and resume by skipping finished ranks.
> 
> The launcher blocks locally, submits Jobs through `huggingface_hub.run_uv_job` (each runs `launch_pickled_pipeline` in a fresh `uv` env from `dependencies`), and enforces `workers` with polling plus `max_retries`. Workers are selected via `DATATROVE_JOB_ARRAY_INDEX`; local `logging_dir` is rejected; HF tokens/secrets are stripped from persisted `executor.pik`/`executor.json` and passed only as Job secrets. Multi-stage flows use `depends=` (fail-fast or `run_on_dependency_fail`), `HfFileSystem` cache invalidation when waiting on remote completions, and auto-creation of `hf://` logging repos/buckets.
> 
> Also exports the executor from `datatrove.executor`, documents it in the README, and adds three `*_jobs.py` examples (filter, tokenize, minhash) plus unit tests that mock the Jobs API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff0c3cc666962a20e0b41258d84f59bcbf81c0b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
