### PR TITLE
fix(jobs): default python= to the coordinator's version

### DIFF
--- a/src/datatrove/executor/jobs.py
+++ b/src/datatrove/executor/jobs.py
@@ -4,6 +4,7 @@ import json
 import math
 import os
 import random
+import sys
 import tempfile
 import time
 from collections import deque
@@ -94,7 +95,12 @@ class JobsPipelineExecutor(PipelineExecutor):
         depends: another JobsPipelineExecutor that must finish before this one starts.
         skip_completed: whether to skip tasks completed in previous runs (default True).
         randomize_start_duration: max seconds to randomly delay the start of each task.
-        python: Python version for the Job's ``uv`` environment (e.g. ``"3.12"``).
+        python: Python version for the Job's ``uv`` environment (e.g. ``"3.12"``). Defaults
+            to the launching interpreter's ``major.minor``: the executor is dill-pickled, and
+            dill ships functions as *bytecode*, which is not portable across Python versions —
+            a mismatched worker interpreter fails at unpickle time with a segfault rather
+            than an error. Pass an explicit version only if the Job environment really should
+            differ (and matches where the pickle is loaded).
         namespace: Hugging Face namespace to launch the Jobs under (defaults to the
             authenticated user).
         labels: extra labels attached to each Job.
@@ -175,7 +181,10 @@ class JobsPipelineExecutor(PipelineExecutor):
         self.timeout = timeout
         self.tasks_per_job = tasks_per_job
         self.depends = depends
-        self.python = python
+        # Default to the coordinator's interpreter: dill serializes functions as
+        # version-specific bytecode, so a worker on a different minor version dies
+        # at unpickle time with a tracebackless segfault (exit 139).
+        self.python = python if python is not None else f"{sys.version_info.major}.{sys.version_info.minor}"
         self.namespace = namespace
         self.labels = labels
         self.token = token

--- a/tests/executor/test_jobs.py
+++ b/tests/executor/test_jobs.py
@@ -208,6 +208,16 @@ class TestJobsExecutor(unittest.TestCase):
         create_repo.assert_not_called()
         create_bucket.assert_not_called()
 
+    def test_python_defaults_to_coordinator_version(self):
+        """dill ships version-specific bytecode: an unset python= must match the coordinator."""
+        import sys
+
+        log_dir = get_datafolder("memory://jobs-test/python-default")
+        executor = JobsPipelineExecutor(pipeline=[_EmitBlock()], tasks=1, logging_dir=log_dir)
+        self.assertEqual(executor.python, f"{sys.version_info.major}.{sys.version_info.minor}")
+        explicit = JobsPipelineExecutor(pipeline=[_EmitBlock()], tasks=1, logging_dir=log_dir, python="3.11")
+        self.assertEqual(explicit.python, "3.11")
+
     def test_invalid_workers_and_tasks_per_job_rejected(self):
         """Nonsensical concurrency settings fail loudly instead of silently launching nothing."""
         log_dir = get_datafolder("memory://jobs-test/validation")


### PR DESCRIPTION
**What**

`JobsPipelineExecutor` dill-pickles itself for the workers, and dill serializes functions as *bytecode* — which is not portable across Python minor versions. When the coordinator's interpreter differs from the Job environment's, the worker dies at `dill.load` with a tracebackless segfault (exit 139), which is indistinguishable from an inference-server or infra crash in the Job logs.

This PR defaults `python=` to the launching interpreter's `major.minor` instead of the image/system default. An explicit `python=` is unchanged and remains the escape hatch if the Job environment should genuinely differ (and matches wherever the pickle is loaded).

Slurm/Local/Ray workers inherently share the coordinator's interpreter (same venv/process/cluster env); this makes Jobs match that implicit contract instead of being the one backend where a silent mismatch is possible.

**How this was found**

A coordinator on Python 3.14 with `python=` unset killed five consecutive GPU workers across two flavors and two inference engines, all exit 139 with nothing in the logs — it looked exactly like a vLLM/SGLang server crash. Isolated locally in ~10 seconds:

```
uv run --python 3.14 dump.py   # dill.dump a closure, CONTENTS_FMODE
uv run --python 3.12 load.py   # dill.load → segfault, exit 139
```

**Verification**

- New unit test: unset → coordinator's version; explicit → respected (14/14 in `test_jobs.py`)
- End-to-end smoke on real Jobs: 3.14 coordinator, `python=` unset, 2 × cpu-basic tasks — workers ran under 3.14 via the default, completed, wrote output (previously this exact configuration was the reliable kill)

**Note on the behavior change**

Previously an unset `python=` meant "whatever the Job image ships". Anyone relying on that must now pass it explicitly — but given the failure mode is an undebuggable segfault and the executor is experimental, defaulting to the only version guaranteed to load the pickle seems like the right trade. Happy to switch to a launch-time warning instead if you'd rather keep the old default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFPZeB5rADPYFsMWTjNnZi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default Job Python version for experimental Jobs executor; wrong assumption about image Python could surprise users, but mismatched unpickle is a severe silent failure mode.
> 
> **Overview**
> **`JobsPipelineExecutor`** now sets **`python=`** to the launching interpreter's **`major.minor`** when omitted, instead of leaving it unset for the Job image default.
> 
> Because the coordinator **dill-pickles** the executor for workers and **dill** embeds **version-specific bytecode**, a worker on a different Python minor version can **segfault at unpickle** (exit 139) with little logging. Defaulting **`python`** aligns the Job **`uv`** environment with the coordinator, matching how other executors implicitly share the same interpreter.
> 
> Explicit **`python="3.11"`** (etc.) is unchanged. Docs and an inline comment explain the failure mode. A unit test asserts the default tracks **`sys.version_info`** and that an explicit value is kept.
> 
> **Behavior change:** callers who relied on unset **`python=`** meaning "whatever the image ships" must pass **`python`** explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24c950c4ae1de78cf5e66d4627c3d8a61c0379ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->