### PR TITLE
feat(jobs): env= passthrough on JobsPipelineExecutor

### DIFF
--- a/src/datatrove/executor/jobs.py
+++ b/src/datatrove/executor/jobs.py
@@ -108,6 +108,11 @@ class JobsPipelineExecutor(PipelineExecutor):
             as the ``HF_TOKEN`` secret so it can read/write the logging_dir.
         secrets: extra secrets passed to each Job (merged with the ``HF_TOKEN`` secret; an
             ``HF_TOKEN`` key here overrides the resolved token).
+        env: extra environment variables set in each Job (e.g. vLLM/sglang tuning knobs).
+            User keys override the executor's defaults (``HF_HUB_DISABLE_PROGRESS_BARS``,
+            ``PYTHONUNBUFFERED``); ``DATATROVE_JOB_ARRAY_INDEX`` is reserved and rejected.
+            Unlike ``secrets``, these values are persisted (in the shared logging_dir's
+            ``executor.json``/``executor.pik``) — use ``secrets`` for anything sensitive.
         max_retries: how many times to relaunch a Job that ends in a non-success state
             within a single run (default 1). Ranks still failed after that are logged and
             left incomplete — :meth:`run` does NOT raise; rerun to resume. A dependent
@@ -156,6 +161,7 @@ class JobsPipelineExecutor(PipelineExecutor):
         labels: dict[str, str] | None = None,
         token: str | None = None,
         secrets: dict[str, Any] | None = None,
+        env: dict[str, str] | None = None,
         max_retries: int = 1,
         poll_interval: int = 15,
         run_on_dependency_fail: bool = False,
@@ -173,6 +179,8 @@ class JobsPipelineExecutor(PipelineExecutor):
             raise ValueError(f"tasks_per_job must be >= 1, got {tasks_per_job}.")
         if workers != -1 and workers < 1:
             raise ValueError(f"workers must be -1 (unlimited) or >= 1, got {workers}.")
+        if env and ARRAY_INDEX_ENV_VAR in env:
+            raise ValueError(f"env must not set {ARRAY_INDEX_ENV_VAR}: it is reserved for task addressing.")
         self.tasks = tasks
         self.workers = workers
         self.flavor = flavor
@@ -189,6 +197,7 @@ class JobsPipelineExecutor(PipelineExecutor):
         self.labels = labels
         self.token = token
         self.secrets = secrets
+        self.env = env
         self.max_retries = max_retries
         self.poll_interval = poll_interval
         self.run_on_dependency_fail = run_on_dependency_fail
@@ -351,9 +360,11 @@ class JobsPipelineExecutor(PipelineExecutor):
             python=self.python,
             image=self.image,
             env={
-                ARRAY_INDEX_ENV_VAR: str(array_index),
                 "HF_HUB_DISABLE_PROGRESS_BARS": "1",
                 "PYTHONUNBUFFERED": "1",
+                **(self.env or {}),
+                # last so user env can never clobber task addressing (also rejected at init)
+                ARRAY_INDEX_ENV_VAR: str(array_index),
             },
             secrets={"HF_TOKEN": token, **(self.secrets or {})},
             flavor=self.flavor,

--- a/tests/executor/test_jobs.py
+++ b/tests/executor/test_jobs.py
@@ -225,6 +225,60 @@ class TestJobsExecutor(unittest.TestCase):
             with self.assertRaises(ValueError):
                 JobsPipelineExecutor(pipeline=[_EmitBlock()], tasks=2, logging_dir=log_dir, **kwargs)
 
+    def test_env_passthrough_to_jobs(self):
+        """env= must reach run_uv_job, with user keys overriding defaults but never the array index."""
+        log_dir = get_datafolder("memory://jobs-test/env-passthrough")
+        executor = JobsPipelineExecutor(
+            pipeline=[_EmitBlock()],
+            tasks=1,
+            logging_dir=log_dir,
+            token="hf_faketoken",
+            env={"VLLM_ATTENTION_BACKEND": "FLASHINFER", "PYTHONUNBUFFERED": "0"},
+            poll_interval=0,
+        )
+        fake_run, fake_inspect, _ = _make_fake_jobs(executor)
+        seen: dict[str, str] = {}
+
+        def recording_run(script, *, env=None, **kwargs):
+            seen.update(env)
+            return fake_run(script, env=env, **kwargs)
+
+        with patch("huggingface_hub.run_uv_job", recording_run), patch("huggingface_hub.inspect_job", fake_inspect):
+            executor.run()
+
+        self.assertEqual(seen["VLLM_ATTENTION_BACKEND"], "FLASHINFER")
+        self.assertEqual(seen["PYTHONUNBUFFERED"], "0")  # user value wins over the executor default
+        self.assertEqual(seen["HF_HUB_DISABLE_PROGRESS_BARS"], "1")  # untouched default survives
+        self.assertEqual(seen[ARRAY_INDEX_ENV_VAR], "0")  # reserved key still set by the executor
+        # unlike secrets, env is part of the persisted executor state (documented contract)
+        with log_dir.open("executor.json", "r") as f:
+            self.assertIn("VLLM_ATTENTION_BACKEND", f.read())
+
+    def test_env_reserved_key_never_clobbers_array_index(self):
+        """Even if the reserved key sneaks past init (e.g. attribute mutation), the launch merge wins."""
+        log_dir = get_datafolder("memory://jobs-test/env-clobber")
+        executor = JobsPipelineExecutor(
+            pipeline=[_EmitBlock()], tasks=1, logging_dir=log_dir, token="hf_faketoken", poll_interval=0
+        )
+        executor.env = {ARRAY_INDEX_ENV_VAR: "7"}  # bypasses the init check on purpose
+        fake_run, fake_inspect, _ = _make_fake_jobs(executor)
+        seen: dict[str, str] = {}
+
+        def recording_run(script, *, env=None, **kwargs):
+            seen.update(env)
+            return fake_run(script, env=env, **kwargs)
+
+        with patch("huggingface_hub.run_uv_job", recording_run), patch("huggingface_hub.inspect_job", fake_inspect):
+            executor.run()
+
+        self.assertEqual(seen[ARRAY_INDEX_ENV_VAR], "0")  # executor's value, not the injected "7"
+
+    def test_env_reserved_key_rejected(self):
+        """Setting the reserved array-index variable via env= must fail loudly at init."""
+        log_dir = get_datafolder("memory://jobs-test/env-reserved")
+        with self.assertRaises(ValueError):
+            JobsPipelineExecutor(pipeline=[_EmitBlock()], tasks=1, logging_dir=log_dir, env={ARRAY_INDEX_ENV_VAR: "7"})
+
     def test_credentials_not_persisted_to_logging_dir(self):
         """token= and secrets= must never end up in executor.pik / executor.json on the shared logging_dir."""
         log_dir = get_datafolder("memory://jobs-test/credentials")


### PR DESCRIPTION
**What**

Adds an `env=` parameter to `JobsPipelineExecutor`, mirroring the existing `secrets=`: extra environment variables set in each launched Job, passed through to `run_uv_job(env=...)`.

**Why**

Inference pipelines regularly need engine knobs in the worker environment (`VLLM_ATTENTION_BACKEND`, sglang memory flags, etc.). The executor currently hardcodes the Job env, so the only workaround is baking variables into a custom image or the script itself.

**Usage**

```python
executor = JobsPipelineExecutor(
    pipeline=[
        HuggingFaceDatasetReader("davanstrien/my-sources", text_key="text"),
        InferenceRunner(rollout_fn=rollout, config=InferenceConfig(model="Qwen/Qwen3.5-9B", server="vllm")),
        ParquetWriter("hf://buckets/davanstrien/run/output"),
    ],
    tasks=20,
    flavor="l4x1",
    logging_dir="hf://buckets/davanstrien/run/logs",
    env={
        "VLLM_ATTENTION_BACKEND": "FLASHINFER",
        "VLLM_USE_DEEP_GEMM": "0",  # engine tuning per run, no custom image needed
    },
)
```

**Design**

- User keys override the executor's two QoL defaults (`HF_HUB_DISABLE_PROGRESS_BARS`, `PYTHONUNBUFFERED`).
- `DATATROVE_JOB_ARRAY_INDEX` is reserved: rejected with a `ValueError` at init, and merged last at the launch site so it can't be clobbered even if it sneaks past.
- Unlike `secrets=`, `env` values are part of the persisted executor state in the shared `logging_dir` (`executor.json` / `executor.pik`) — the docstring tells users to put anything sensitive in `secrets=` instead.

**Tests**

Three new tests: passthrough + default-override + persistence contract; reserved-key rejection; reserved-key clobber guard. 17/17 green locally on 3.12, ruff clean. Additive change to the experimental executor surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive change to the experimental Jobs executor with clear validation and tests; main caveat is non-secret env values landing in persisted executor metadata on the shared logging_dir.
> 
> **Overview**
> Adds an **`env=`** knob on **`JobsPipelineExecutor`** so each Hugging Face Job can get extra environment variables (e.g. vLLM/sglang tuning) without baking them into a custom image. Values are merged into **`run_uv_job(env=...)`** alongside the existing QoL defaults; user keys **override** `HF_HUB_DISABLE_PROGRESS_BARS` and `PYTHONUNBUFFERED`, while **`DATATROVE_JOB_ARRAY_INDEX`** stays reserved—rejected at init and forced last at launch so task addressing cannot be overridden.
> 
> Unlike **`secrets=`**, **`env`** is stored on the executor and **persists** in the shared `logging_dir` (`executor.json` / `executor.pik`); the docstring steers sensitive values toward **`secrets=`**. Three tests cover passthrough, persistence, and the reserved-key guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f044f10c25a18a79b045d04b9d6a9c156d6b618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->