### PR TITLE
Add a small local dataset audit example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ You can check the following [examples](examples):
 - [process_common_crawl_dump.py](examples/process_common_crawl_dump.py) full pipeline to read commoncrawl warc files, extract their text content, filters and save the resulting data to s3. Runs on slurm
 - [tokenize_c4.py](examples/tokenize_c4.py) reads data directly from huggingface's hub to tokenize the english portion of the C4 dataset using the `gpt2` tokenizer
 - [estimate_tokens.py](examples/estimate_tokens.py) estimate total token counts for large HF datasets — needed to set the correct `SamplerFilter` rate when creating a random shuffled subsample (e.g. 100B tokens from a multi-trillion-token dataset). Streams a small sample per dataset, converges on the average tokens/doc, and multiplies by the total row count.
+- [audit_dataset.py](examples/audit_dataset.py) runs a small local dataset audit, capturing rejected documents and comparing summary statistics before and after filtering.
 - [smol_data.py](examples/smol_data.py) builds ~100B token subsets, 50-30-20 mixtures, and shuffled variants for several large Hugging Face datasets
 - [minhash_deduplication.py](examples/minhash_deduplication.py) full pipeline to run minhash deduplication of text data
 - [sentence_deduplication.py](examples/sentence_deduplication.py) example to run sentence level exact deduplication

--- a/examples/audit_dataset.py
+++ b/examples/audit_dataset.py
@@ -1,0 +1,81 @@
+"""Run a small, local dataset audit with reviewable filtering artifacts.
+
+Usage:
+    python examples/audit_dataset.py --work-dir /tmp/datatrove-audit
+
+The length threshold is only an example. Choose quality rules from the intended
+dataset and model use case, then inspect both kept and rejected documents.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+from datatrove.executor import LocalPipelineExecutor
+from datatrove.pipeline.filters import LambdaFilter
+from datatrove.pipeline.readers import JsonlReader
+from datatrove.pipeline.stats import DocStats, StatsMerger
+from datatrove.pipeline.writers import JsonlWriter
+
+
+MIN_CHARS = 80
+
+
+def write_sample_input(input_dir: Path) -> None:
+    input_dir.mkdir(parents=True, exist_ok=True)
+    documents = [
+        {"id": "short", "text": "Limited offer. Buy now!", "source": "demo", "dump": "2026-08"},
+        {
+            "id": "guide",
+            "text": "A dataset audit keeps filtering decisions reviewable by saving accepted and rejected records.",
+            "source": "demo",
+            "dump": "2026-08",
+        },
+        {
+            "id": "provenance",
+            "text": "Provenance fields record where a document came from and which source snapshot was processed.",
+            "source": "demo",
+            "dump": "2026-08",
+        },
+    ]
+    with (input_dir / "sample.jsonl").open("w") as output:
+        for document in documents:
+            output.write(json.dumps(document) + "\n")
+
+
+def merge_stats(stats_dir: Path) -> None:
+    list(StatsMerger(input_folder=stats_dir, output_folder=stats_dir)())
+
+
+def main(work_dir: Path) -> None:
+    input_dir = work_dir / "input"
+    output_dir = work_dir / "output"
+    stats_dir = work_dir / "stats"
+    write_sample_input(input_dir)
+
+    executor = LocalPipelineExecutor(
+        pipeline=[
+            JsonlReader(input_dir, glob_pattern="*.jsonl"),
+            DocStats(stats_dir / "before", groups_to_compute=["summary", "histogram"]),
+            LambdaFilter(
+                lambda document: len(document.text) >= MIN_CHARS,
+                exclusion_writer=JsonlWriter(output_dir / "removed", compression=None),
+            ),
+            DocStats(stats_dir / "after", groups_to_compute=["summary", "histogram"]),
+            JsonlWriter(output_dir / "kept", compression=None),
+        ],
+        tasks=1,
+        workers=1,
+        logging_dir=work_dir / "logs",
+    )
+    executor.run()
+
+    merge_stats(stats_dir / "before")
+    merge_stats(stats_dir / "after")
+    print(f"Audit artifacts written to {work_dir}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--work-dir", type=Path, default=Path("dataset-audit"))
+    main(parser.parse_args().work_dir)


### PR DESCRIPTION
Closes #485.

This adds a self-contained local example that combines the existing audit-oriented pipeline blocks:

- a three-document JSONL sample with source and dump metadata;
- document statistics before and after filtering;
- a simple length filter with rejected-document capture; and
- separate kept, removed, stats, and log artifacts.

The length threshold is explicitly presented as an example rather than a general quality rule. The README quickstart list links to the new script.

Validation:

- parsed the example with `ast` and checked the 119-column limit;
- executed its sample-input function and verified provenance plus the expected two-kept/one-rejected split;
- checked that the example instantiates `JsonlReader`, `DocStats`, `LambdaFilter`, `JsonlWriter`, and `StatsMerger`.

The full DataTrove pipeline was not run locally because the available Python is 3.9 and the task-local Python download could not connect to GitHub's release host. No model, dataset, or heavy optional dependency was downloaded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a new example script only; no changes to library behavior or production pipelines.
> 
> **Overview**
> Adds **`examples/audit_dataset.py`**, a self-contained local workflow for reviewing filter impact: it writes a three-document JSONL sample (with `source` / `dump` metadata), runs **`DocStats`** before and after a **`LambdaFilter`** (example min length), writes kept and rejected docs via **`JsonlWriter`** (including **`exclusion_writer`** on the filter), merges stats with **`StatsMerger`**, and leaves artifacts under a configurable `--work-dir`.
> 
> The README **Quickstart examples** list now links to this script and briefly describes what it does. The script frames the length rule as an illustrative audit pattern, not a recommended quality default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acbb98fdb319f52737ee6fc6508ce0b039cf99ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->