### PR TITLE
fix(writers): clear operations after commit in HuggingFaceDatasetWriter

### DIFF
--- a/src/datatrove/pipeline/writers/huggingface.py
+++ b/src/datatrove/pipeline/writers/huggingface.py
@@ -126,6 +126,7 @@ class HuggingFaceDatasetWriter(ParquetWriter):
                 else:
                     logger.error(f"Failed to create commit: {e.server_message or str(e)}")
                     raise e
+        self.operations = []
 
     def _on_file_switch(self, original_name, old_filename, new_filename):
         """

--- a/tests/pipeline/writers/test_huggingface_dataset_writer.py
+++ b/tests/pipeline/writers/test_huggingface_dataset_writer.py
@@ -1,0 +1,104 @@
+"""Tests for HuggingFaceDatasetWriter.
+
+Unit tests mock the underlying ``huggingface_hub`` APIs (``create_repo`` /
+``preupload_lfs_files`` / ``create_commit``) so they run without network access.
+The fake ``create_commit`` mimics huggingface_hub's real bookkeeping: it flags
+each ``CommitOperationAdd`` as committed on success and raises the same
+``ValueError`` huggingface_hub raises when a caller tries to reuse an
+already-committed operation. This reproduces (and guards against) the writer
+reuse bug that occurs when a ``SlurmPipelineExecutor`` with ``tasks_per_job > 1``
+runs multiple ranks sequentially against the same writer instance.
+"""
+
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from datatrove.data import Document
+from datatrove.pipeline.readers.parquet import ParquetReader
+from datatrove.pipeline.writers.huggingface import HuggingFaceDatasetWriter
+
+from ...utils import require_pyarrow
+
+
+def _make_docs(n: int, start: int = 0) -> list[Document]:
+    return [Document(text=f"hello {i}", id=f"doc-{i}", metadata={"split": "train"}) for i in range(start, start + n)]
+
+
+def _fake_create_commit(*_args, operations, **_kwargs):
+    for op in operations:
+        if getattr(op, "_is_committed", False):
+            raise ValueError(
+                f"CommitOperationAdd {op} has already being committed and cannot be reused. "
+                "Please create a new CommitOperationAdd object if you want to create a new commit."
+            )
+    for op in operations:
+        op._is_committed = True
+
+
+@require_pyarrow
+class TestHuggingFaceDatasetWriterReuse(unittest.TestCase):
+    """Regression test for reusing one writer instance across multiple ranks.
+
+    SlurmPipelineExecutor with tasks_per_job > 1 runs several ranks
+    sequentially against the same pipeline step instances, so close() must be
+    safe to call more than once on the same writer.
+    """
+
+    def setUp(self) -> None:
+        self.tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp_dir)
+        self._create_repo_patcher = patch("datatrove.pipeline.writers.huggingface.create_repo", return_value=None)
+        self._preupload_patcher = patch(
+            "datatrove.pipeline.writers.huggingface.preupload_lfs_files", return_value=None
+        )
+        self._create_commit_patcher = patch(
+            "datatrove.pipeline.writers.huggingface.create_commit",
+            side_effect=_fake_create_commit,
+        )
+        self._create_repo_patcher.start()
+        self._preupload_patcher.start()
+        self.mock_create_commit = self._create_commit_patcher.start()
+        self.addCleanup(self._create_repo_patcher.stop)
+        self.addCleanup(self._preupload_patcher.stop)
+        self.addCleanup(self._create_commit_patcher.stop)
+
+    def _make_writer(self) -> HuggingFaceDatasetWriter:
+        return HuggingFaceDatasetWriter(dataset="org/my-dataset", local_working_dir=self.tmp_dir, cleanup=False)
+
+    def test_reused_writer_commits_each_rank_independently(self) -> None:
+        writer = self._make_writer()
+
+        with writer:
+            writer.write(_make_docs(1)[0], rank=0)
+        with writer:
+            writer.write(_make_docs(1, start=1)[0], rank=1)
+
+        self.assertEqual(self.mock_create_commit.call_count, 2)
+        first_ops = self.mock_create_commit.call_args_list[0].kwargs["operations"]
+        second_ops = self.mock_create_commit.call_args_list[1].kwargs["operations"]
+        self.assertEqual(len(first_ops), 1)
+        self.assertEqual(len(second_ops), 1)
+        self.assertNotEqual(first_ops[0], second_ops[0])
+        self.assertEqual(writer.operations, [])
+
+    def test_reused_writer_round_trips_all_ranks(self) -> None:
+        writer = self._make_writer()
+        docs_rank0 = _make_docs(2, start=0)
+        docs_rank1 = _make_docs(2, start=2)
+
+        with writer:
+            for doc in docs_rank0:
+                writer.write(doc, rank=0)
+        with writer:
+            for doc in docs_rank1:
+                writer.write(doc, rank=1)
+
+        reader = ParquetReader(self.tmp_dir)
+        read_back = list(reader())
+        self.assertEqual(len(read_back), len(docs_rank0) + len(docs_rank1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fixes #501 `HuggingFaceDatasetWriter` reusing already-committed `CommitOperationAdd` objects when the same writer instance is reused across ranks (e.g. `SlurmPipelineExecutor(tasks_per_job > 1)`, which runs multiple ranks sequentially against the same pipeline step instances).
- [HuggingFaceDatasetWriter.close()](https://github.com/huggingface/datatrove/blob/9a2b1f9dd85c2178228da418a22f6cc90c013e03/src/datatrove/pipeline/writers/huggingface.py#L101) accumulated uploaded files onto `self.operations` but never cleared it after a successful commit, so the next `close()` call on the same instance resent operations `huggingface_hub` had already flagged `_is_committed = True`, raising `ValueError: CommitOperationAdd ... has already being committed and cannot be reused.`
- `self.operations` in [HuggingFaceDatasetWriter.close()](https://github.com/huggingface/datatrove/blob/9a2b1f9dd85c2178228da418a22f6cc90c013e03/src/datatrove/pipeline/writers/huggingface.py#L101) is now reset to `[]` once the commit loop exits successfully, mirroring how [ParquetWriter.close()](https://github.com/huggingface/datatrove/blob/9a2b1f9dd85c2178228da418a22f6cc90c013e03/src/datatrove/pipeline/writers/parquet.py#L101) already clears its own per-cycle state (`self._batches.clear()`, `self._writers.clear()`) on every call.

## Tests

- Added `tests/pipeline/writers/test_huggingface_dataset_writer.py`, mocking `create_repo` / `preupload_lfs_files` / `create_commit` at the import site (no network access). The fake `create_commit` reproduces [huggingface_hub's real bookkeeping (sets `_is_committed = True` on success, raises `ValueError` if an operation is reused)](https://github.com/huggingface/huggingface_hub/blob/7d62d95fa01c7e1db9f8680cdf6f96b681f031d7/src/huggingface_hub/hf_api.py#L5216), so the tests exercise the actual failure mechanism from the issue.
  - `test_reused_writer_commits_each_rank_independently`: drives two full write/close cycles on the same writer instance (the exact reuse pattern from `SlurmPipelineExecutor`) and asserts each commit only includes that cycle's new operations, and `writer.operations == []` after the second `close()`.
  - `test_reused_writer_round_trips_all_ranks`: same reuse pattern, then reads the staged output back via `ParquetReader` to confirm no data loss/corruption across the two cycles.
- [x] Confirmed both new tests fail with the exact `ValueError` from the issue when the **fix is reverted**, and **pass with it applied**.
- [x] `.venv/bin/python -m pytest -sv tests/pipeline/writers/` — 35 passed, no regressions.
- [x] `ruff check` / `ruff format --check` on changed files — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line state reset after successful commit in the HF dataset writer; behavior aligns with ParquetWriter’s per-close cleanup, with targeted regression tests and no auth or data-model changes.
> 
> **Overview**
> Fixes a **reuse bug** when the same `HuggingFaceDatasetWriter` instance handles multiple ranks in sequence (e.g. `SlurmPipelineExecutor` with `tasks_per_job > 1`). After a successful Hub commit, **`self.operations` is now cleared**, so the next `close()` only commits fresh `CommitOperationAdd` objects instead of re-sending ones `huggingface_hub` already marked committed (which raised `ValueError`).
> 
> Adds **offline regression tests** that mock `create_repo` / `preupload_lfs_files` / `create_commit` (including `_is_committed` behavior) to assert two write/close cycles on one writer each get their own commit and that parquet output round-trips across ranks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25a2effd71958b5386f0ecfd42b458a152c682be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->