### PR TITLE
docs: add ParquetWriter class docstring

### DIFF
--- a/src/datatrove/pipeline/writers/parquet.py
+++ b/src/datatrove/pipeline/writers/parquet.py
@@ -21,8 +21,8 @@ class ParquetWriter(DiskWriter):
         max_file_size: max size per parquet file, in bytes. Files rotate when they reach this size; a closed
             file is always readable, so smaller values lose less work if a job dies mid-run
         schema: an explicit `pyarrow.Schema` for the output. If None, the schema is inferred from the first
-            batch — a value that only appears in later batches (e.g. a `None`, or a new metadata key) then
-            fails the write. Pass an explicit schema when fields can be missing or heterogeneous
+            document. Fields or types introduced later may be omitted or cause a schema mismatch, depending
+            on batching. Pass an explicit schema when fields can be missing or heterogeneous
         save_media_bytes: save the media bytes column
         use_content_defined_chunking: write CDC-optimized parquet (better Xet deduplication on the Hub).
             True uses the default options; a dict is passed through to pyarrow

--- a/src/datatrove/pipeline/writers/parquet.py
+++ b/src/datatrove/pipeline/writers/parquet.py
@@ -9,6 +9,26 @@ DEFAULT_CDC_OPTIONS = {"min_chunk_size": 256 * 1024, "max_chunk_size": 1024 * 10
 
 
 class ParquetWriter(DiskWriter):
+    """Write data to datafolder (local or remote) in Parquet format
+
+    Args:
+        output_folder: a str, tuple or DataFolder where data should be saved
+        output_filename: the filename to use when saving data, including extension. Can contain placeholders such as `${rank}` or metadata tags `${tag}`
+        compression: parquet compression codec: "snappy" (default), "gzip", "brotli", "lz4", "zstd" or None
+        adapter: a custom function to "adapt" the Document format to the desired output format
+        batch_size: number of documents to buffer before writing a parquet batch
+        expand_metadata: save each metadata entry in a different column instead of as a dictionary
+        max_file_size: max size per parquet file, in bytes. Files rotate when they reach this size; a closed
+            file is always readable, so smaller values lose less work if a job dies mid-run
+        schema: an explicit `pyarrow.Schema` for the output. If None, the schema is inferred from the first
+            batch — a value that only appears in later batches (e.g. a `None`, or a new metadata key) then
+            fails the write. Pass an explicit schema when fields can be missing or heterogeneous
+        save_media_bytes: save the media bytes column
+        use_content_defined_chunking: write CDC-optimized parquet (better Xet deduplication on the Hub).
+            True uses the default options; a dict is passed through to pyarrow
+        write_page_index: write the parquet page index for faster filtered reads
+    """
+
     default_output_filename: str = "${rank}.parquet"
     name = "📒 Parquet"
     _requires_dependencies = ["pyarrow"]


### PR DESCRIPTION
`ParquetWriter` is the only writer without a class docstring — `JsonlWriter`, `DiskWriter`, and `HuggingFaceBucketWriter` all have one. Since the repo has no `docs/` dir, docstrings are the effective documentation surface.

The gap that matters most is `schema=`: passing an explicit schema (added in #330) avoids the first-batch schema-inference failure mode (a `None` or a new metadata key appearing in a later batch fails the write after the work is done), but today the only way to discover the parameter is to read `_write`. The new docstring documents all init args in the same format the sibling writers use.

Docs only, no behaviour change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no code path or API behavior modifications.
> 
> **Overview**
> Adds a **class docstring** to `ParquetWriter` so it matches sibling writers (`JsonlWriter`, etc.) and documents all `__init__` parameters in one place.
> 
> The new text highlights operational knobs that were easy to miss—especially **`schema`** (explicit `pyarrow.Schema` vs first-batch inference and late-batch mismatch failures), plus **`max_file_size`**, CDC/Xet options, and **`write_page_index`**. **Docs only; no runtime behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5eeaac2f36258ae6069af81eabac321b34f7a5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->