### PR TITLE
fix: raise huggingface-hub floor to 1.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.10.0"
 dependencies = [
   "dill>=0.3.0",
   "fsspec>=2023.12.2",
-  "huggingface-hub>=1.5.0", # use the v1 client line by default; >=1.5.0 required for HF storage buckets
+  "huggingface-hub>=1.6.0", # use the v1 client line by default; >=1.6.0 for HfFileSystemResolvedBucketPath (bucket writes)
   "humanize",
   "loguru>=0.7.0",
   "multiprocess",

--- a/uv.lock
+++ b/uv.lock
@@ -17,9 +17,6 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
-[manifest]
-overrides = [{ name = "transformers", specifier = ">=5.0" }]
-
 [[package]]
 name = "absl-py"
 version = "2.4.0"
@@ -1417,7 +1414,6 @@ all = [
     { name = "tldextract" },
     { name = "tokenizers" },
     { name = "trafilatura" },
-    { name = "transformers" },
     { name = "typer" },
     { name = "urduhack" },
     { name = "vllm" },
@@ -1481,7 +1477,6 @@ dev = [
     { name = "tldextract" },
     { name = "tokenizers" },
     { name = "trafilatura" },
-    { name = "transformers" },
     { name = "typer" },
     { name = "urduhack" },
     { name = "vllm" },
@@ -1503,7 +1498,6 @@ inference = [
     { name = "python-magic" },
     { name = "pyyaml" },
     { name = "sglang" },
-    { name = "transformers" },
     { name = "typer" },
     { name = "vllm" },
     { name = "warcio" },
@@ -1604,7 +1598,6 @@ testing = [
     { name = "tldextract" },
     { name = "tokenizers" },
     { name = "trafilatura" },
-    { name = "transformers" },
     { name = "typer" },
     { name = "urduhack" },
     { name = "vllm" },
@@ -1640,7 +1633,7 @@ requires-dist = [
     { name = "fsspec", specifier = ">=2023.12.2" },
     { name = "ftfy", marker = "extra == 'processing'" },
     { name = "httpx", marker = "extra == 'inference'" },
-    { name = "huggingface-hub", specifier = ">=1.0.0" },
+    { name = "huggingface-hub", specifier = ">=1.6.0" },
     { name = "humanize" },
     { name = "indic-nlp-library", marker = "extra == 'multilingual'" },
     { name = "inscriptis", marker = "extra == 'processing'" },
@@ -1681,7 +1674,6 @@ requires-dist = [
     { name = "tokenizers", marker = "extra == 'processing'" },
     { name = "tqdm" },
     { name = "trafilatura", marker = "extra == 'processing'", specifier = ">=1.8.0,<1.12.0" },
-    { name = "transformers", marker = "extra == 'inference'", specifier = ">=5.0" },
     { name = "typer", marker = "extra == 'inference'" },
     { name = "urduhack", marker = "extra == 'multilingual'" },
     { name = "vllm", marker = "extra == 'inference'", specifier = ">=0.10.0" },


### PR DESCRIPTION
`disk_base.py` imports `HfFileSystemResolvedBucketPath`, which first shipped in huggingface-hub 1.6.0, but the floor says 1.5.0 (both were introduced in the same commit, 23c540f / #484). The import is lazy, so with hub 1.5.x installed the failure surfaces at bucket-write time in a running pipeline rather than at install.

Possibly worth a follow-up: there's no direct `hf-xet` pin, and a low hub floor can resolve to an `hf-xet` below the API change recent hub expects — flagging rather than fixing here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency floor and lockfile-only changes; low runtime risk aside from stricter minimum hub version for consumers.
> 
> **Overview**
> Raises the core **`huggingface-hub`** requirement from **>=1.5.0** to **>=1.6.0** so installs match what **`disk_base.py`** needs for lazy imports of **`HfFileSystemResolvedBucketPath`** during HF bucket write retries—avoiding runtime import failures on hub 1.5.x.
> 
> **`uv.lock`** is refreshed to pin **`huggingface-hub>=1.6.0`** and drops the **`transformers>=5.0`** manifest override plus explicit **`transformers`** entries from several optional extra dependency lists in the lock metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88f9c4ed2ca7557cc9a659c5bf4bae875c9e68bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->