### PR TITLE
ci: switch PyPI release to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -31,11 +31,19 @@ jobs:
       - name: Build the dist files
         run: python -m build .
 
-      - name: Publish to the test PyPI
+      - name: Test installing the built wheel and running tests
+        # same gate the old install-from-TestPyPI step provided, without the
+        # scratch registry: prove the built artifact (not the source tree)
+        # installs and passes tests before anything irreversible happens
+        run: |
+          python -m pip install uv
+          uv pip install --system "$(ls dist/*.whl)[testing]"
+          python -m nltk.downloader punkt
+          python -m pytest -sv ./tests/
+
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.1
         with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
           verbose: true
           print-hash: true
 
@@ -44,16 +52,8 @@ jobs:
         run: |
           echo TAG_NAME=$(grep '^version' pyproject.toml | head -1 | cut -d '"' -f 2) >> $GITHUB_OUTPUT
 
-      - name: Test installing from test PyPI and running tests
-        # install the wheel we just uploaded to testpypi directly, and all other dependencies from normal pypi
-        # uses the version number to fetch the url of the .whl file
-        run: |
-          python -m pip install uv
-          uv pip install --system datatrove[testing]@$(curl -s https://test.pypi.org/simple/datatrove/ | grep ${{ steps.get_tag_name.outputs.TAG_NAME }}-py3 | sed -nE 's/.*href="([^"]+)".*/\1/p')
-          python -m nltk.downloader punkt
-          python -m pytest -sv ./tests/
-
       - name: Tag the release
+        # after the publish on purpose: a failed upload must not leave a tag
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           script: |
@@ -65,9 +65,3 @@ jobs:
             })
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # needed to tag
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.1
-        with:
-          verbose: true
-          print-hash: true

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -32,9 +32,6 @@ jobs:
         run: python -m build .
 
       - name: Test installing the built wheel and running tests
-        # same gate the old install-from-TestPyPI step provided, without the
-        # scratch registry: prove the built artifact (not the source tree)
-        # installs and passes tests before anything irreversible happens
         run: |
           python -m pip install uv
           uv pip install --system "$(ls dist/*.whl)[testing]"
@@ -53,7 +50,7 @@ jobs:
           echo TAG_NAME=$(grep '^version' pyproject.toml | head -1 | cut -d '"' -f 2) >> $GITHUB_OUTPUT
 
       - name: Tag the release
-        # after the publish on purpose: a failed upload must not leave a tag
+        # runs after the publish so a failed upload doesn't leave a tag
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           script: |

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -9,11 +9,10 @@ jobs:
   release:
     needs: testing
     runs-on: ubuntu-latest
-    env:
-      TWINE_USERNAME: __token__
 
     permissions:
       contents: write  # needed to create a tag
+      id-token: write  # needed for PyPI trusted publishing (OIDC)
 
     steps:
       - name: Checkout Repo
@@ -27,15 +26,18 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -U twine build
+          pip install -U build
 
       - name: Build the dist files
         run: python -m build .
 
       - name: Publish to the test PyPI
-        env:
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
-        run: twine upload dist/* --skip-existing --repository=testpypi
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          verbose: true
+          print-hash: true
 
       - name: Get tag name
         id: get_tag_name
@@ -65,6 +67,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # needed to tag
 
       - name: Publish to PyPI
-        env:
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: twine upload dist/* --repository=pypi
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.1
+        with:
+          verbose: true
+          print-hash: true


### PR DESCRIPTION
The May 6 release attempt passed tests and failed at the "Publish to test PyPI" step on PyPI keys. Rather than rotate the tokens, this switches publishing to [trusted publishing](https://docs.pypi.org/trusted-publishers/): GitHub proves the workflow's identity to PyPI per-run via OIDC, and no long-lived secret exists to expire again.

**Changes**
- Upload step → `pypa/gh-action-pypi-publish` (SHA-pinned, v1.14.1 — same pin as [lerobot's release workflow](https://github.com/huggingface/lerobot/blob/ef88d4e52b9f3a16638e4b73202d619b7606fd41/.github/workflows/release.yml#L113))
- `id-token: write` added to the release job's permissions; `TWINE_USERNAME` env and the twine install dropped
- **TestPyPI removed from the flow.** 
  - the install-back gate now installs the **built wheel from `dist/`** and runs the full test suite *before* publish — same artifact check, no scratch registry, and it deletes the fragile curl/grep of the TestPyPI simple index (which matched the raw pyproject version string against PEP 440-normalized filenames)
  - the registry-round-trip check moves to the rc rehearsal (below)
- **Tag creation moved after the publish** — a failed upload no longer leaves a stale `vX.Y.Z` tag

Resulting order: tests → build → **install wheel + pytest** → publish to PyPI → tag. Everything before publish can fail and re-run freely; "version exists" on PyPI stays a hard failure. `TEST_PYPI_TOKEN` and `PYPI_TOKEN` become unused on merge and can be deleted from repo secrets.

**Tested — dry run on this branch ([run 31608389848](https://github.com/huggingface/datatrove/actions/runs/31608389848))**

The trusted publisher is configured on pypi.org (owner `huggingface`, repo `datatrove`, workflow `pypi-release.yml`, no environment) and the workflow was dispatched on this branch as-is — version still 0.9.0, so nothing could publish. Result, every step proven except the final upload itself:
- test suite green (3.10–3.13), build green
- wheel-install gate green: the built wheel installs with `[testing]` extras and passes the full suite
- **OIDC exchange succeeded** against the live publisher config (log shows `username: __token__` + sigstore attestations) — the run reached a real authenticated upload attempt
- PyPI rejected with `400 File already exists (datatrove-0.9.0...)`, exactly as intended: existing release files are immutable, and no tag was created (tag runs after publish)

The only untested path is a successful upload + tag, which is what the `0.10.0rc1` rehearsal (#506) exercises after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production release and tagging path and removes TestPyPI as a safety net; misconfigured trusted publishing or workflow permissions could block or mis-route releases until fixed.
> 
> **Overview**
> **Replaces long-lived PyPI/TestPyPI twine tokens** with GitHub OIDC trusted publishing via `pypa/gh-action-pypi-publish`, adding `id-token: write` and dropping twine/`TWINE_*` usage.
> 
> **Release flow is reordered and simplified:** after build, the workflow installs the **local wheel** from `dist/` (with `[testing]`) and runs the full pytest suite, then publishes to production PyPI, then creates the git tag—so a failed upload no longer leaves a tag and TestPyPI is removed entirely.
> 
> **Pre-publish validation** no longer depends on scraping the TestPyPI simple index; the same “install what we ship” check happens against the artifact about to be uploaded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 625d5c177b3a939ce2fd6cb14c625acff2a7d32e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->