### PR TITLE
release: bump version to 0.10.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datatrove"
-version = "0.9.0"  # expected format is one of x.y.z.dev0, or x.y.z.rc1 or x.y.z (no to dashes, yes to dots)
+version = "0.10.0rc1"  # expected format is one of x.y.z.dev0, x.y.zrc1 or x.y.z (PEP 440 canonical — the release workflow greps this raw string against normalized wheel filenames)
 description = "HuggingFace library to process and filter large amounts of webdata"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1350,7 +1350,7 @@ wheels = [
 
 [[package]]
 name = "datatrove"
-version = "0.9.0"
+version = "0.10.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "dill" },


### PR DESCRIPTION
Rehearsal release for the trusted-publishing pipeline (#505): `0.10.0rc1` is invisible to plain `pip install datatrove` (pre-releases aren't selected by default), so dispatching the release workflow on this version exercises both upload paths end to end at near-zero stakes before the real 0.10.0.

**Why `0.10.0rc1` and not `0.10.0.rc1`** (what the old pyproject comment suggested): the workflow's install-back gate greps the raw pyproject version against the TestPyPI simple index, where wheel filenames carry the PEP 440-normalized form (`datatrove-0.10.0rc1-py3-...`). The dotted string requires a character between `0` and `rc1` that the normalized filename doesn't have, so the run would die after build+upload. Comment updated to match.

Release content since 0.9.0 (34 commits): bucket support (#484), `JobsPipelineExecutor` (#497), Python 3.13, transformers-5/vllm bump, uv migration, huggingface-hub ≥1.6.0 floor (#504), CI SHA pins.

Sequencing: merge after #505 + the PyPI trusted publishers are live on both registries; first dispatch runs on this version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KjiAz4WrVL28ViDedke2ju

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version and lockfile changes with no runtime code paths affected.
> 
> **Overview**
> Bumps the package version from **0.9.0** to **`0.10.0rc1`** in `pyproject.toml` and refreshes **`uv.lock`** so the editable `datatrove` entry matches.
> 
> The inline version comment is rewritten to describe PEP 440 canonical pre-release tags (`0.10.0rc1` vs `0.10.0.rc1`) and why the release workflow’s TestPyPI install step greps wheel names using the raw `pyproject` string—avoiding a mismatch with normalized filenames like `datatrove-0.10.0rc1-py3-...`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fa40bcec39a5f39502a01ee512012cd7909ef10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->