### PR TITLE
fix: pin xxhash<4 (4.0.0 breaks all dedup pipelines)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ processing = [
   "ftfy",
   "fasteners",
   "regex",
-  "xxhash",
+  "xxhash<4",
   "pyahocorasick",
 ]
 decont = [

--- a/uv.lock
+++ b/uv.lock
@@ -1678,7 +1678,7 @@ requires-dist = [
     { name = "urduhack", marker = "extra == 'multilingual'" },
     { name = "vllm", marker = "extra == 'inference'", specifier = ">=0.10.0" },
     { name = "warcio", marker = "extra == 'io'" },
-    { name = "xxhash", marker = "extra == 'processing'" },
+    { name = "xxhash", marker = "extra == 'processing'", specifier = "<4" },
     { name = "zstandard", marker = "extra == 'io'" },
 ]
 provides-extras = ["cli", "io", "s3", "processing", "decont", "multilingual", "inference", "ray", "quality", "testing", "all", "dev"]


### PR DESCRIPTION
## What broke

[xxhash 4.0.0](https://pypi.org/project/xxhash/4.0.0/) was released on 2026-08-12 and removed implicit `str` encoding: `xxh32_intdigest` / `xxh64_intdigest` now raise `TypeError: Strings must be encoded before hashing` when given a `str`.

`datatrove.utils.hashes.xxhash` passes `str` straight through, and `xxhash` was declared unbounded in the `processing` extra — so **any fresh install picks up 4.0.0 and every dedup pipeline fails**: minhash, exact dedup, URL dedup, sentence dedup, bloom filter.

Existing environments and CI were shielded by lockfiles, which is why this surfaced only now — the `0.10.0rc1` release run failed at the "install the built wheel and run the tests" step added in #505 (~30 dedup tests, all `TypeError: Strings must be encoded before hashing`), while the lockfile-based test matrix on the same commit passed.

## What this PR does

Pins `xxhash<4` in the `processing` extra (plus the matching `uv.lock` refresh). Nothing else.

This is deliberately the minimal unbreak: it restores exactly the dependency set that every current user and CI run already has, with no behaviour change, and it also covers any transitive use of xxhash rather than just the call sites in this repo.

**Follow-up (separate PR):** encode to UTF-8 inside `utils/hashes/xxhash.py` and lift the bound. UTF-8 is what xxhash <4 encoded implicitly, so digests are unchanged and existing signatures stay comparable — verified locally against 4.0.0. Keeping that change out of this PR so it can be reviewed on its own rather than under release pressure.

## Testing

- `tests/pipeline/dedup/test_exact_deduplication.py` — 8/8 pass with the pin (all were failing on `TypeError` in the release run).
- Fresh resolution with the bound picks `xxhash` 3.8.1, which accepts `str` and produces digests identical to the 4.0.0 UTF-8-bytes result.
- `uv lock --check` passes.

## Note for maintainers

This is not rc-only: **`pip install datatrove==0.9.0` has been broken for dedup since 2026-08-12** for anyone installing without a lockfile. Worth considering a 0.9.1 patch alongside this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency constraint only; restores prior resolved versions and behavior with no runtime logic changes.
> 
> **Overview**
> **xxhash 4.0.0** no longer hashes bare `str` inputs, which breaks datatrove’s hashing helpers and every dedup path that depended on the previous implicit encoding.
> 
> This PR **caps the `processing` extra at `xxhash<4`** in `pyproject.toml` and refreshes **`uv.lock`** so resolution stays on 3.x (e.g. 3.8.1) with no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4b88ca9dd7dd359c08f1446a4a095236281539c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->