### PR TITLE
docs(jobs): point JobsPipelineExecutor install guidance at the released package

### DIFF
--- a/examples/filter_hf_dataset_jobs.py
+++ b/examples/filter_hf_dataset_jobs.py
@@ -47,10 +47,10 @@ REMOTE_LOGS_PATH = "hf://datasets/my_org/my-filter-logs"
 # datatrove + every extra/dep your pipeline steps need, installed into each Job's uv env.
 # NB: even LambdaFilter needs the `processing` extra — importing datatrove.pipeline.filters
 # eagerly pulls in modules that require `regex`. Match the extras to the steps you use.
-# Installed from git because no released datatrove ships JobsPipelineExecutor yet — with a
-# released version the Job dies at unpickle time (the class doesn't exist in the Job's env).
-# TODO: switch to "datatrove[io,processing]" once a release includes the Jobs executor.
-DEPENDENCIES = ["datatrove[io,processing] @ git+https://github.com/huggingface/datatrove"]
+# JobsPipelineExecutor first ships in datatrove 0.10.0, so the Job needs at least that:
+# with an older datatrove it dies at unpickle time (the class doesn't exist in its env).
+# The bound names the pre-release so it resolves today, and picks 0.10.0 once that is out.
+DEPENDENCIES = ["datatrove[io,processing]>=0.10.0rc1"]
 
 if __name__ == "__main__":
     args = parser.parse_args()

--- a/examples/minhash_deduplication_jobs.py
+++ b/examples/minhash_deduplication_jobs.py
@@ -66,10 +66,10 @@ MINHASH_BASE_PATH = "hf://buckets/my_org/my-minhash/data"
 LOGS_FOLDER = "hf://buckets/my_org/my-minhash/logs"
 
 # datatrove + processing (nltk/xxhash/regex/tokenizers) + bare spacy (English word tokenizer).
-# Installed from git because no released datatrove ships JobsPipelineExecutor yet — with a
-# released version the Job dies at unpickle time (the class doesn't exist in the Job's env).
-# TODO: switch to "datatrove[io,processing]" once a release includes the Jobs executor.
-DEPENDENCIES = ["datatrove[io,processing] @ git+https://github.com/huggingface/datatrove", "spacy"]
+# JobsPipelineExecutor first ships in datatrove 0.10.0, so the Job needs at least that:
+# with an older datatrove it dies at unpickle time (the class doesn't exist in its env).
+# The bound names the pre-release so it resolves today, and picks 0.10.0 once that is out.
+DEPENDENCIES = ["datatrove[io,processing]>=0.10.0rc1", "spacy"]
 
 TOTAL_TASKS = 50
 

--- a/examples/tokenize_hf_dataset_jobs.py
+++ b/examples/tokenize_hf_dataset_jobs.py
@@ -13,7 +13,7 @@ for the full comparison). Two things specific to this multi-stage flow on Jobs:
 - `output_path` MUST be a shared REMOTE path (hf:// or s3://) — both stages run on different machines
   and read/write the same `tokenized-tasks/` folder.
 - The tokens pipeline needs the `processing` extra (there is no separate `tokens` extra): `tokenizers`
-  and `regex` live there. So `dependencies=["datatrove[io,processing]"]`.
+  and `regex` live there. So `dependencies=["datatrove[io,processing]>=0.10.0rc1"]`.
 """
 
 import argparse
@@ -33,10 +33,10 @@ parser.add_argument("--workers", type=int, help="max concurrent Jobs (-1 = all a
 parser.add_argument("--flavor", type=str, help="HF Jobs hardware flavor", default="cpu-basic")
 
 # tokens machinery lives in the `processing` extra (tokenizers + regex); `datasets` comes from `io`.
-# Installed from git because no released datatrove ships JobsPipelineExecutor yet — with a
-# released version the Job dies at unpickle time (the class doesn't exist in the Job's env).
-# TODO: switch to "datatrove[io,processing]" once a release includes the Jobs executor.
-DEPENDENCIES = ["datatrove[io,processing] @ git+https://github.com/huggingface/datatrove"]
+# JobsPipelineExecutor first ships in datatrove 0.10.0, so the Job needs at least that:
+# with an older datatrove it dies at unpickle time (the class doesn't exist in its env).
+# The bound names the pre-release so it resolves today, and picks 0.10.0 once that is out.
+DEPENDENCIES = ["datatrove[io,processing]>=0.10.0rc1"]
 
 if __name__ == "__main__":
     args = parser.parse_args()

--- a/src/datatrove/executor/jobs.py
+++ b/src/datatrove/executor/jobs.py
@@ -86,9 +86,9 @@ class JobsPipelineExecutor(PipelineExecutor):
             image. A custom image must have ``uv`` installed.
         dependencies: pip requirements installed in each Job's ``uv`` environment (passed
             as ``uv run --with``). Must include datatrove and anything your pipeline steps
-            import (e.g. ``"datasets"``). Defaults to ``["datatrove[io]"]``; until this
-            executor is released, point datatrove at the branch, e.g.
-            ``["datatrove[io] @ git+https://github.com/<user>/datatrove@<branch>", "datasets"]``.
+            import (e.g. ``"datasets"``). Defaults to ``["datatrove[io]"]``. This executor
+            needs datatrove>=0.10.0 in the Job, so while 0.10.0 is still a pre-release
+            pin it explicitly, e.g. ``["datatrove[io]>=0.10.0rc1", "datasets"]``.
         timeout: per-Job timeout, as seconds (int) or a string like ``"2h"`` / ``"30m"``.
         tasks_per_job: how many datatrove tasks each Job runs. Reduces the number of Jobs
             launched (default 1).
@@ -136,7 +136,7 @@ class JobsPipelineExecutor(PipelineExecutor):
             tasks=10,
             workers=4,
             logging_dir="hf://datasets/<user>/imdb-processed/logs",
-            dependencies=["datatrove[io]", "datasets"],
+            dependencies=["datatrove[io]>=0.10.0rc1", "datasets"],
             flavor="cpu-basic",
         ).run()
         ```


### PR DESCRIPTION
`JobsPipelineExecutor` first ships in 0.10.0, so its docstring and the three `*_jobs.py` examples told users to install datatrove from git ("until this executor is released..."). `0.10.0rc1` is now on PyPI, so they can point at the released package instead.

Uses `>=0.10.0rc1` rather than a bare `datatrove[io]`, for two reasons:

- A bare requirement resolves to 0.9.0 today, which has no `JobsPipelineExecutor` — the Job would die at unpickle time.
- PEP 440 only considers pre-releases when the specifier itself names one, so `>=0.10.0rc1` picks the rc now and 0.10.0 once that ships. No second edit needed at release time.

Also replaces the "installed from git" comments above each `DEPENDENCIES` line, including a TODO this resolves.

## Testing

Docs and examples only; no package code touched. Verified `>=0.10.0rc1` resolves to `0.10.0rc1` and imports `JobsPipelineExecutor`, and that the same specifier works inside a real Job: a 2-Job `JobsPipelineExecutor` fan-out built its env from the published wheel and completed (200 imdb docs per task, filter, `JsonlWriter` to a bucket). ruff check and format clean.

## Note (not addressed here)

The `dependencies` default is still `["datatrove[io]"]`, which resolves to 0.9.0 while 0.10.0 is a pre-release — so the default is only correct once 0.10.0 ships, and it self-heals then. Worth considering separately whether the default should pin the coordinator's own datatrove version, for the same dill-portability reason `python=` already defaults to the coordinator's interpreter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example dependency strings only; no executor runtime behavior changes.
> 
> **Overview**
> Updates **JobsPipelineExecutor** install guidance now that **0.10.0rc1** is on PyPI: examples and the executor docstring no longer tell users to install datatrove from git.
> 
> `DEPENDENCIES` in the three `*_jobs.py` examples and the docstring example now use **`datatrove[...]>=0.10.0rc1`** instead of a git URL, with comments explaining that older releases lack `JobsPipelineExecutor` (unpickle failures) and that the rc bound resolves today and upgrades to **0.10.0** at release per PEP 440. The executor’s default `dependencies` value is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 840b3cbda07cefaccbb62807616fb538770c15e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->