### PR TITLE
release: bump version to 0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datatrove"
-version = "0.10.0rc1"  # expected format is one of x.y.z.dev0, x.y.zrc1 or x.y.z (PEP 440 canonical — the release workflow greps this raw string against normalized wheel filenames)
+version = "0.10.0"  # expected format is one of x.y.z.dev0, x.y.zrc1 or x.y.z (PEP 440 canonical — the release workflow greps this raw string against normalized wheel filenames)
 description = "HuggingFace library to process and filter large amounts of webdata"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1350,7 +1350,7 @@ wheels = [
 
 [[package]]
 name = "datatrove"
-version = "0.10.0rc1"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "dill" },


### PR DESCRIPTION
Promotes `0.10.0rc1` to `0.10.0`. Bumped with `uv version 0.10.0`, so `pyproject.toml` and `uv.lock` move together (the rc missed the lock half — see #506 — and Bugbot caught the drift).

Merge, then dispatch the "PyPI release" workflow on `main` to publish and tag `v0.10.0`.

## What's in it since 0.9.0

- `JobsPipelineExecutor` — run pipelines on Hugging Face Jobs (#497), plus `python=` defaulting to the coordinator's interpreter (#498) and `env=` passthrough (#499)
- Hugging Face storage bucket support (#484), `huggingface-hub>=1.6.0` floor (#504)
- Inference chat-reasoning fix (#496), `ParquetWriter` docstring (#503)
- Release plumbing: PyPI trusted publishing via OIDC (#505), `xxhash<4` pin (#507), Jobs install guidance pointing at the released package (#509)

## Notes

- `0.10.0rc1` is on PyPI and was exercised end to end: install-back, and a `JobsPipelineExecutor` fan-out on HF Jobs building its environment from the published wheel.
- No doc changes needed: the examples and docstring use `datatrove[io]>=0.10.0rc1`, which resolves to `0.10.0` once this ships.
- `xxhash` stays pinned to `<4` for this release. #508 records why, and why lifting it deserves a considered fix rather than a quick one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime or API code changes—only version metadata and lock sync for publishing.
> 
> **Overview**
> Promotes the package from **`0.10.0rc1`** to stable **`0.10.0`** by updating the PEP 440 version in `pyproject.toml` and the matching **`datatrove`** entry in **`uv.lock`** so the lockfile stays aligned with the release workflow (which greps the raw version string).
> 
> This is a **version-only** change in the diff; feature content for 0.10.0 is already on the release candidate and is intended to ship via the PyPI release workflow after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58cb63ef0f345cf5479321b9a9ff8f823ab59bab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->