### PR TITLE
docs(jobs): drop the pre-release pin now 0.10.0 is out

### DIFF
--- a/examples/filter_hf_dataset_jobs.py
+++ b/examples/filter_hf_dataset_jobs.py
@@ -47,10 +47,9 @@ REMOTE_LOGS_PATH = "hf://datasets/my_org/my-filter-logs"
 # datatrove + every extra/dep your pipeline steps need, installed into each Job's uv env.
 # NB: even LambdaFilter needs the `processing` extra — importing datatrove.pipeline.filters
 # eagerly pulls in modules that require `regex`. Match the extras to the steps you use.
-# JobsPipelineExecutor first ships in datatrove 0.10.0, so the Job needs at least that:
-# with an older datatrove it dies at unpickle time (the class doesn't exist in its env).
-# The bound names the pre-release so it resolves today, and picks 0.10.0 once that is out.
-DEPENDENCIES = ["datatrove[io,processing]>=0.10.0rc1"]
+# The Job needs datatrove>=0.10.0, the release that introduced JobsPipelineExecutor:
+# with an older one it dies at unpickle time (the class doesn't exist in its env).
+DEPENDENCIES = ["datatrove[io,processing]"]
 
 if __name__ == "__main__":
     args = parser.parse_args()

--- a/examples/filter_hf_dataset_jobs.py
+++ b/examples/filter_hf_dataset_jobs.py
@@ -47,8 +47,7 @@ REMOTE_LOGS_PATH = "hf://datasets/my_org/my-filter-logs"
 # datatrove + every extra/dep your pipeline steps need, installed into each Job's uv env.
 # NB: even LambdaFilter needs the `processing` extra — importing datatrove.pipeline.filters
 # eagerly pulls in modules that require `regex`. Match the extras to the steps you use.
-# The Job needs datatrove>=0.10.0, the release that introduced JobsPipelineExecutor:
-# with an older one it dies at unpickle time (the class doesn't exist in its env).
+# The Job needs datatrove>=0.10.0, the release that introduced JobsPipelineExecutor.
 DEPENDENCIES = ["datatrove[io,processing]"]
 
 if __name__ == "__main__":

--- a/examples/minhash_deduplication_jobs.py
+++ b/examples/minhash_deduplication_jobs.py
@@ -66,10 +66,9 @@ MINHASH_BASE_PATH = "hf://buckets/my_org/my-minhash/data"
 LOGS_FOLDER = "hf://buckets/my_org/my-minhash/logs"
 
 # datatrove + processing (nltk/xxhash/regex/tokenizers) + bare spacy (English word tokenizer).
-# JobsPipelineExecutor first ships in datatrove 0.10.0, so the Job needs at least that:
-# with an older datatrove it dies at unpickle time (the class doesn't exist in its env).
-# The bound names the pre-release so it resolves today, and picks 0.10.0 once that is out.
-DEPENDENCIES = ["datatrove[io,processing]>=0.10.0rc1", "spacy"]
+# The Job needs datatrove>=0.10.0, the release that introduced JobsPipelineExecutor:
+# with an older one it dies at unpickle time (the class doesn't exist in its env).
+DEPENDENCIES = ["datatrove[io,processing]", "spacy"]
 
 TOTAL_TASKS = 50
 

--- a/examples/minhash_deduplication_jobs.py
+++ b/examples/minhash_deduplication_jobs.py
@@ -66,8 +66,7 @@ MINHASH_BASE_PATH = "hf://buckets/my_org/my-minhash/data"
 LOGS_FOLDER = "hf://buckets/my_org/my-minhash/logs"
 
 # datatrove + processing (nltk/xxhash/regex/tokenizers) + bare spacy (English word tokenizer).
-# The Job needs datatrove>=0.10.0, the release that introduced JobsPipelineExecutor:
-# with an older one it dies at unpickle time (the class doesn't exist in its env).
+# The Job needs datatrove>=0.10.0, the release that introduced JobsPipelineExecutor.
 DEPENDENCIES = ["datatrove[io,processing]", "spacy"]
 
 TOTAL_TASKS = 50

--- a/examples/tokenize_hf_dataset_jobs.py
+++ b/examples/tokenize_hf_dataset_jobs.py
@@ -13,7 +13,7 @@ for the full comparison). Two things specific to this multi-stage flow on Jobs:
 - `output_path` MUST be a shared REMOTE path (hf:// or s3://) — both stages run on different machines
   and read/write the same `tokenized-tasks/` folder.
 - The tokens pipeline needs the `processing` extra (there is no separate `tokens` extra): `tokenizers`
-  and `regex` live there. So `dependencies=["datatrove[io,processing]>=0.10.0rc1"]`.
+  and `regex` live there. So `dependencies=["datatrove[io,processing]"]`.
 """
 
 import argparse
@@ -33,10 +33,9 @@ parser.add_argument("--workers", type=int, help="max concurrent Jobs (-1 = all a
 parser.add_argument("--flavor", type=str, help="HF Jobs hardware flavor", default="cpu-basic")
 
 # tokens machinery lives in the `processing` extra (tokenizers + regex); `datasets` comes from `io`.
-# JobsPipelineExecutor first ships in datatrove 0.10.0, so the Job needs at least that:
-# with an older datatrove it dies at unpickle time (the class doesn't exist in its env).
-# The bound names the pre-release so it resolves today, and picks 0.10.0 once that is out.
-DEPENDENCIES = ["datatrove[io,processing]>=0.10.0rc1"]
+# The Job needs datatrove>=0.10.0, the release that introduced JobsPipelineExecutor:
+# with an older one it dies at unpickle time (the class doesn't exist in its env).
+DEPENDENCIES = ["datatrove[io,processing]"]
 
 if __name__ == "__main__":
     args = parser.parse_args()

--- a/examples/tokenize_hf_dataset_jobs.py
+++ b/examples/tokenize_hf_dataset_jobs.py
@@ -33,8 +33,7 @@ parser.add_argument("--workers", type=int, help="max concurrent Jobs (-1 = all a
 parser.add_argument("--flavor", type=str, help="HF Jobs hardware flavor", default="cpu-basic")
 
 # tokens machinery lives in the `processing` extra (tokenizers + regex); `datasets` comes from `io`.
-# The Job needs datatrove>=0.10.0, the release that introduced JobsPipelineExecutor:
-# with an older one it dies at unpickle time (the class doesn't exist in its env).
+# The Job needs datatrove>=0.10.0, the release that introduced JobsPipelineExecutor.
 DEPENDENCIES = ["datatrove[io,processing]"]
 
 if __name__ == "__main__":

--- a/src/datatrove/executor/jobs.py
+++ b/src/datatrove/executor/jobs.py
@@ -86,9 +86,9 @@ class JobsPipelineExecutor(PipelineExecutor):
             image. A custom image must have ``uv`` installed.
         dependencies: pip requirements installed in each Job's ``uv`` environment (passed
             as ``uv run --with``). Must include datatrove and anything your pipeline steps
-            import (e.g. ``"datasets"``). Defaults to ``["datatrove[io]"]``. This executor
-            needs datatrove>=0.10.0 in the Job, so while 0.10.0 is still a pre-release
-            pin it explicitly, e.g. ``["datatrove[io]>=0.10.0rc1", "datasets"]``.
+            import (e.g. ``["datatrove[io]", "datasets"]``). Defaults to ``["datatrove[io]"]``.
+            The Job needs datatrove>=0.10.0, the release that introduced this executor:
+            with an older one it dies at unpickle time (the class doesn't exist in its env).
         timeout: per-Job timeout, as seconds (int) or a string like ``"2h"`` / ``"30m"``.
         tasks_per_job: how many datatrove tasks each Job runs. Reduces the number of Jobs
             launched (default 1).
@@ -136,7 +136,7 @@ class JobsPipelineExecutor(PipelineExecutor):
             tasks=10,
             workers=4,
             logging_dir="hf://datasets/<user>/imdb-processed/logs",
-            dependencies=["datatrove[io]>=0.10.0rc1", "datasets"],
+            dependencies=["datatrove[io]", "datasets"],
             flavor="cpu-basic",
         ).run()
         ```


### PR DESCRIPTION
Follow-up to #509. That PR pointed the `JobsPipelineExecutor` docs at `datatrove[io]>=0.10.0rc1`, which was correct while 0.10.0 was a pre-release. Now that 0.10.0 is on PyPI, a plain requirement resolves to a version that has the executor, so the bounds and the prose explaining them can go.

Removes:

- `>=0.10.0rc1` from the docstring example and the three `*_jobs.py` examples
- the "while 0.10.0 is still a pre-release, pin it explicitly" sentence in the docstring, and the matching "the bound names the pre-release" comment in each example — both are no longer true

What stays is the constraint that will remain true: the Job needs datatrove>=0.10.0, because with an older one it dies at unpickle time.

Docs and examples only; no package code touched. ruff check and format clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-only changes; no package behavior or dependency resolution logic is modified.
> 
> **Overview**
> Now that **datatrove 0.10.0** is on PyPI, the docs and HF Jobs examples no longer pin `datatrove[...]>=0.10.0rc1` or explain the old pre-release workaround.
> 
> **`JobsPipelineExecutor`** docstring and the three `*_jobs.py` examples use plain extras like `datatrove[io,processing]` (and `spacy` where needed). The **≥0.10.0** requirement is still documented briefly: older datatrove fails at unpickle time because `JobsPipelineExecutor` is not in those releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aaf68807be4876ef0ee97c0a9d82a574edcbdbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->