### PR TITLE
fix(stats): handle empty documents

### DIFF
--- a/src/datatrove/pipeline/stats/base.py
+++ b/src/datatrove/pipeline/stats/base.py
@@ -13,6 +13,10 @@ from datatrove.pipeline.stats.config import DEFAULT_TOP_K_CONFIG, GROUP, STAT_TY
 from datatrove.utils.stats import MetricStatsDict
 
 
+def _safe_divide(numerator: int | float, denominator: int | float) -> float:
+    return numerator / denominator if denominator else 0.0
+
+
 class BaseStats(PipelineStep):
     """
     Datatrove block for computing statistics of dataset.

--- a/src/datatrove/pipeline/stats/contamination_stats.py
+++ b/src/datatrove/pipeline/stats/contamination_stats.py
@@ -2,7 +2,7 @@ from typing import get_args
 
 from datatrove.data import Document
 from datatrove.io import DataFolderLike
-from datatrove.pipeline.stats.base import BaseStats
+from datatrove.pipeline.stats.base import BaseStats, _safe_divide
 from datatrove.pipeline.stats.config import DEFAULT_TOP_K_CONFIG, GROUP, TopKConfig
 from datatrove.utils.text import TextNormConfig, simplify_text
 from datatrove.utils.typeshelper import Languages
@@ -45,6 +45,7 @@ class WordsContaminationStats(BaseStats):
 
         doc_words = word_tokenizer.word_tokenize(simplify_text(doc.text, self.norm_config))
         return {
-            f"words_contamination_{self.words[0]}": sum([1 for word in doc_words if word in self.words])
-            / len(doc_words)
+            f"words_contamination_{self.words[0]}": _safe_divide(
+                sum([1 for word in doc_words if word in self.words]), len(doc_words)
+            )
         }

--- a/src/datatrove/pipeline/stats/doc_stats.py
+++ b/src/datatrove/pipeline/stats/doc_stats.py
@@ -3,7 +3,7 @@ from typing import get_args
 
 from datatrove.data import Document
 from datatrove.io import DataFolderLike
-from datatrove.pipeline.stats.base import BaseStats
+from datatrove.pipeline.stats.base import BaseStats, _safe_divide
 from datatrove.pipeline.stats.config import DEFAULT_TOP_K_CONFIG, GROUP, TopKConfig
 from datatrove.utils.text import PUNCTUATION
 
@@ -41,10 +41,16 @@ class DocStats(BaseStats):
     def extract_stats(self, doc: Document) -> dict[str, int | float]:
         return {
             "length": len(doc.text),
-            "white_space_ratio": sum([1 for c in doc.text if c.isspace()]) / len(doc.text),
-            "non_alpha_digit_ratio": sum([1 for c in doc.text if not c.isalpha() and not c.isdigit()]) / len(doc.text),
-            "digit_ratio": sum([1 for c in doc.text if c.isdigit()]) / len(doc.text),
-            "uppercase_ratio": sum([1 for c in doc.text if c.isupper()]) / len(doc.text),
-            "elipsis_ratio": sum(len(elipsis) for elipsis in self.elipsis_regex.findall(doc.text)) / len(doc.text),
-            "punctuation_ratio": sum(len(punc) for punc in self.punc_regex.findall(doc.text)) / len(doc.text),
+            "white_space_ratio": _safe_divide(sum([1 for c in doc.text if c.isspace()]), len(doc.text)),
+            "non_alpha_digit_ratio": _safe_divide(
+                sum([1 for c in doc.text if not c.isalpha() and not c.isdigit()]), len(doc.text)
+            ),
+            "digit_ratio": _safe_divide(sum([1 for c in doc.text if c.isdigit()]), len(doc.text)),
+            "uppercase_ratio": _safe_divide(sum([1 for c in doc.text if c.isupper()]), len(doc.text)),
+            "elipsis_ratio": _safe_divide(
+                sum(len(elipsis) for elipsis in self.elipsis_regex.findall(doc.text)), len(doc.text)
+            ),
+            "punctuation_ratio": _safe_divide(
+                sum(len(punc) for punc in self.punc_regex.findall(doc.text)), len(doc.text)
+            ),
         }

--- a/src/datatrove/pipeline/stats/line_stats.py
+++ b/src/datatrove/pipeline/stats/line_stats.py
@@ -4,16 +4,16 @@ from datatrove.data import Document
 from datatrove.io import DataFolderLike
 from datatrove.pipeline.filters.c4_filters import END_PUNCTUATION
 from datatrove.pipeline.filters.gopher_repetition_filter import find_duplicates
-from datatrove.pipeline.stats.base import BaseStats
+from datatrove.pipeline.stats.base import BaseStats, _safe_divide
 from datatrove.pipeline.stats.config import DEFAULT_TOP_K_CONFIG, GROUP, TopKConfig
 
 
 def get_max_chars_per_line_ratio(lines, chars: int) -> float:
-    return sum([1 for line in lines if len(line) <= chars]) / len(lines)
+    return _safe_divide(sum([1 for line in lines if len(line) <= chars]), len(lines))
 
 
 def get_min_chars_per_line_ratio(lines, chars: int) -> float:
-    return sum([1 for line in lines if len(line) >= chars]) / len(lines)
+    return _safe_divide(sum([1 for line in lines if len(line) >= chars]), len(lines))
 
 
 def is_bullet_line(line: str):
@@ -70,7 +70,7 @@ class LineStats(BaseStats):
         line_dups, char_dups = find_duplicates(lines)
         return {
             "n_lines": n_lines,
-            "avg_line_length": (sum([len(line) for line in lines]) / len(lines)),
+            "avg_line_length": _safe_divide(sum([len(line) for line in lines]), len(lines)),
             **{
                 f"short_line_ratio_chars_{chars}": get_max_chars_per_line_ratio(lines, chars)
                 for chars in self.short_max_chars
@@ -79,9 +79,10 @@ class LineStats(BaseStats):
                 f"long_line_ratio_chars_{chars}": get_min_chars_per_line_ratio(lines, chars)
                 for chars in self.long_max_chars
             },
-            "lines_ending_with_terminal_mark_ratio": sum(1 for line in lines if line.endswith(END_PUNCTUATION))
-            / len(lines),
-            "bullet_point_lines_ratio": sum(1 for line in lines if is_bullet_line(line)) / len(lines),
-            "line_duplicates": line_dups / len(lines),
-            "line_char_duplicates": char_dups / sum(len(line) for line in lines),
+            "lines_ending_with_terminal_mark_ratio": _safe_divide(
+                sum(1 for line in lines if line.endswith(END_PUNCTUATION)), len(lines)
+            ),
+            "bullet_point_lines_ratio": _safe_divide(sum(1 for line in lines if is_bullet_line(line)), len(lines)),
+            "line_duplicates": _safe_divide(line_dups, len(lines)),
+            "line_char_duplicates": _safe_divide(char_dups, sum(len(line) for line in lines)),
         }

--- a/src/datatrove/pipeline/stats/paragraph_stats.py
+++ b/src/datatrove/pipeline/stats/paragraph_stats.py
@@ -3,16 +3,16 @@ from typing import get_args
 from datatrove.data import Document
 from datatrove.io import DataFolderLike
 from datatrove.pipeline.filters.gopher_repetition_filter import find_duplicates
-from datatrove.pipeline.stats.base import BaseStats
+from datatrove.pipeline.stats.base import BaseStats, _safe_divide
 from datatrove.pipeline.stats.config import DEFAULT_TOP_K_CONFIG, GROUP, TopKConfig
 
 
 def get_short_paragraph_ratio(paragraphs: list[str], threshold: int) -> float:
-    return sum([1 for paragraph in paragraphs if len(paragraph) <= threshold]) / len(paragraphs)
+    return _safe_divide(sum([1 for paragraph in paragraphs if len(paragraph) <= threshold]), len(paragraphs))
 
 
 def get_long_paragraph_ratio(paragraphs: list[str], threshold: int) -> float:
-    return sum([1 for paragraph in paragraphs if len(paragraph) >= threshold]) / len(paragraphs)
+    return _safe_divide(sum([1 for paragraph in paragraphs if len(paragraph) >= threshold]), len(paragraphs))
 
 
 class ParagraphStats(BaseStats):
@@ -60,7 +60,7 @@ class ParagraphStats(BaseStats):
 
         return {
             "n_paragraphs": n_paragraphs,
-            "avg_paragraph_length": sum([len(p) for p in paragraphs]) / n_paragraphs,
+            "avg_paragraph_length": _safe_divide(sum([len(p) for p in paragraphs]), n_paragraphs),
             **{
                 f"short_paragraph_ratio_{chars}": get_short_paragraph_ratio(paragraphs, chars)
                 for chars in self.short_paragraph_max_chars_threshold
@@ -69,6 +69,6 @@ class ParagraphStats(BaseStats):
                 f"long_paragraph_ratio_{chars}": get_long_paragraph_ratio(paragraphs, chars)
                 for chars in self.long_paragraph_max_chars_threshold
             },
-            "paragraph_duplicates": paragraph_dups / n_paragraphs,
-            "paragraph_char_duplicates": paragraph_char_dups / sum(len(p) for p in paragraphs),
+            "paragraph_duplicates": _safe_divide(paragraph_dups, n_paragraphs),
+            "paragraph_char_duplicates": _safe_divide(paragraph_char_dups, sum(len(p) for p in paragraphs)),
         }

--- a/src/datatrove/pipeline/stats/sentence_stats.py
+++ b/src/datatrove/pipeline/stats/sentence_stats.py
@@ -2,18 +2,18 @@ from typing import get_args
 
 from datatrove.data import Document
 from datatrove.io import DataFolderLike
-from datatrove.pipeline.stats.base import BaseStats
+from datatrove.pipeline.stats.base import BaseStats, _safe_divide
 from datatrove.pipeline.stats.config import DEFAULT_TOP_K_CONFIG, GROUP, TopKConfig
 from datatrove.utils.typeshelper import Languages
 from datatrove.utils.word_tokenizers import load_word_tokenizer
 
 
 def get_short_sentence_ratio(sentences: list[str], threshold: int) -> float:
-    return sum([1 for sentence in sentences if len(sentence) <= threshold]) / len(sentences)
+    return _safe_divide(sum([1 for sentence in sentences if len(sentence) <= threshold]), len(sentences))
 
 
 def get_long_sentence_ratio(sentences: list[str], threshold: int) -> float:
-    return sum([1 for sentence in sentences if len(sentence) >= threshold]) / len(sentences)
+    return _safe_divide(sum([1 for sentence in sentences if len(sentence) >= threshold]), len(sentences))
 
 
 class SentenceStats(BaseStats):
@@ -57,7 +57,7 @@ class SentenceStats(BaseStats):
 
         return {
             "n_sentences": len(sentences),
-            "avg_sentence_length": sum([len(s) for s in sentences]) / len(sentences),
+            "avg_sentence_length": _safe_divide(sum([len(s) for s in sentences]), len(sentences)),
             **{
                 f"short_sentence_ratio_{chars}": get_short_sentence_ratio(sentences, chars)
                 for chars in self.short_sentence_max_chars_threshold

--- a/src/datatrove/pipeline/stats/word_stats.py
+++ b/src/datatrove/pipeline/stats/word_stats.py
@@ -3,18 +3,18 @@ from typing import get_args
 from datatrove.data import Document
 from datatrove.io import DataFolderLike
 from datatrove.pipeline.filters.gopher_quality_filter import STOP_WORDS
-from datatrove.pipeline.stats.base import BaseStats
+from datatrove.pipeline.stats.base import BaseStats, _safe_divide
 from datatrove.pipeline.stats.config import DEFAULT_TOP_K_CONFIG, GROUP, TopKConfig
 from datatrove.utils.typeshelper import Languages
 from datatrove.utils.word_tokenizers import load_word_tokenizer
 
 
 def get_short_word_ratio(words: list[str], threshold: int) -> float:
-    return sum([1 for word in words if len(word) <= threshold]) / len(words)
+    return _safe_divide(sum([1 for word in words if len(word) <= threshold]), len(words))
 
 
 def get_long_word_ratio(words: list[str], threshold: int) -> float:
-    return sum([1 for word in words if len(word) >= threshold]) / len(words)
+    return _safe_divide(sum([1 for word in words if len(word) >= threshold]), len(words))
 
 
 class WordStats(BaseStats):
@@ -66,8 +66,8 @@ class WordStats(BaseStats):
 
         return {
             "n_words": len(words),
-            "avg_word_length": sum([len(word) for word in words]) / len(words),
-            "avg_words_per_line": len(words) / len(lines),
+            "avg_word_length": _safe_divide(sum([len(word) for word in words]), len(words)),
+            "avg_words_per_line": _safe_divide(len(words), len(lines)),
             **{
                 f"short_word_ratio_{chars}": get_short_word_ratio(words, chars)
                 for chars in self.short_word_max_chars_threshold
@@ -76,8 +76,8 @@ class WordStats(BaseStats):
                 f"long_word_ratio_{chars}": get_long_word_ratio(words, chars)
                 for chars in self.long_word_max_chars_threshold
             },
-            "type_token_ratio": len(set(words)) / len(words),
-            "uppercase_word_ratio": sum([1 for word in words if word.isupper()]) / len(words),
-            "capitalized_word_ratio": sum([1 for word in words if word.istitle()]) / len(words),
-            "stop_word_ratio": sum([1 for word in words if word in self.stop_words]) / len(words),
+            "type_token_ratio": _safe_divide(len(set(words)), len(words)),
+            "uppercase_word_ratio": _safe_divide(sum([1 for word in words if word.isupper()]), len(words)),
+            "capitalized_word_ratio": _safe_divide(sum([1 for word in words if word.istitle()]), len(words)),
+            "stop_word_ratio": _safe_divide(sum([1 for word in words if word in self.stop_words]), len(words)),
         }

--- a/tests/pipeline/stats/test_stats.py
+++ b/tests/pipeline/stats/test_stats.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import unittest
 from typing import get_args
+from unittest.mock import patch
 
 from datatrove.data import Document
 from datatrove.io import get_datafolder
@@ -15,6 +16,7 @@ from datatrove.pipeline.stats import (
     LangStats,
     LineStats,
     ParagraphStats,
+    SentenceStats,
     StatsMerger,
     TokenStats,
     TopKConfig,
@@ -47,6 +49,56 @@ DOCS = [
     Document("1", "2", metadata={"url": "test2.cz"}),
     Document("1", "3", metadata={"url": "test3.cz"}),
 ]
+
+
+class _EmptyTokenizer:
+    def word_tokenize(self, text: str) -> list[str]:
+        return []
+
+    def sent_tokenize(self, text: str) -> list[str]:
+        return []
+
+
+@require_tldextract
+class TestEmptyDocumentStats(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp_dir = get_datafolder(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp_dir.path)
+
+    def test_empty_document_produces_finite_stats(self) -> None:
+        doc = Document("", "empty", metadata={"url": "https://example.com"})
+        empty_tokenizer = _EmptyTokenizer()
+
+        with (
+            patch("datatrove.pipeline.stats.contamination_stats.load_word_tokenizer", return_value=empty_tokenizer),
+            patch("datatrove.pipeline.stats.sentence_stats.load_word_tokenizer", return_value=empty_tokenizer),
+            patch("datatrove.pipeline.stats.word_stats.load_word_tokenizer", return_value=empty_tokenizer),
+        ):
+            stats_blocks = [
+                DocStats(self.tmp_dir),
+                LineStats(self.tmp_dir, ignore_empty_lines=True),
+                ParagraphStats(self.tmp_dir),
+                SentenceStats(self.tmp_dir),
+                WordStats(self.tmp_dir),
+                WordsContaminationStats(self.tmp_dir, ["example"]),
+            ]
+
+            for stats_block in stats_blocks:
+                with self.subTest(stats_block=stats_block.__class__.__name__):
+                    stats = stats_block.extract_stats(doc)
+                    for name, value in stats.items():
+                        expected = 1 if isinstance(stats_block, LineStats) and name == "n_lines" else 0
+                        self.assertEqual(value, expected)
+                        self.assertTrue(math.isfinite(value))
+
+    def test_empty_document_with_default_line_stats_produces_finite_stats(self) -> None:
+        doc = Document("", "empty", metadata={"url": "https://example.com"})
+
+        stats = LineStats(self.tmp_dir).extract_stats(doc)
+
+        self.assertEqual(stats["n_lines"], 1)
+        self.assertEqual(stats["line_char_duplicates"], 0.0)
+        self.assertTrue(all(math.isfinite(value) for value in stats.values()))
 
 
 @require_tldextract


### PR DESCRIPTION
## Summary

- return `0.0` for ratios and averages whose denominator is empty
- apply the same behavior across document, line, paragraph, sentence, word, and word-contamination stats
- add regression coverage for empty documents across all affected stats blocks

Empty or fully filtered documents currently raise `ZeroDivisionError` in several
stats blocks. This can stop a data-audit pipeline before downstream cleaning has
a chance to handle the sample. The helper preserves existing results for
non-empty inputs and keeps count metrics such as `n_lines` unchanged.

## Tests

- focused stats regression tests — 7 passed, 6 subtests passed
- Ruff lint and format checks
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f7213bb564d3ff4a533a05ec3b89e420df7f1401. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->