### PR TITLE
fix(dedup): support zero document priority

### DIFF
--- a/src/datatrove/pipeline/dedup/exact_dedup.py
+++ b/src/datatrove/pipeline/dedup/exact_dedup.py
@@ -33,7 +33,7 @@ class ExactDedupConfig:
         content_getter: Callable[[Document], bytes | str] Function for getting the content of a document.
         document_priority: Callable[[Document], int] Function for determining the priority of a document.
             Only the document with the highest priority will be preserved, out of duplicates.
-            The document priority must be in range [1, 65535]
+            The document priority must be in range [0, 65535]
     """
 
     content_getter: Callable[[Document], bytes | str]
@@ -69,7 +69,7 @@ def get_sig_dtype(config: HashConfig) -> np.dtype:
 class ExactDedupSignature(PipelineStep):
     """ExactDedup: First pipeline step
         Creates a signature for content in each document. Each HashSig has n hash, the priority the doc id. Before saving
-        them the hashes are sorted based on (hash, -priority, doc_id).
+        them the hashes are sorted based on (hash, priority descending, doc_id).
 
     Args:
         output_folder: folder where signatures are saved
@@ -103,16 +103,14 @@ class ExactDedupSignature(PipelineStep):
         sig_dtype = get_sig_dtype(self.config.hash_config)
         priority_max = np.iinfo(sig_dtype["priority"]).max
 
-        # 0 will stay as is, so we can't use 0 as a priority
-        assert all(sig[1] >= 1 and sig[1] <= priority_max for sig in signatures), (
-            f"priority must be between 1 and {priority_max}"
-        )
+        if not all(0 <= sig[1] <= priority_max for sig in signatures):
+            raise ValueError(f"priority must be between 0 and {priority_max}")
         signatures = np.array(signatures, dtype=sig_dtype)
 
         # Ensure that the highest priority is always first
-        signatures["priority"] = -signatures["priority"]
+        signatures["priority"] = priority_max - signatures["priority"]
         signatures.sort(axis=0)
-        signatures["priority"] = -signatures["priority"]
+        signatures["priority"] = priority_max - signatures["priority"]
 
         # Same code as in sentence_dedup
         hashes_per_worker = self.config.hash_config.max // self.finder_workers

--- a/tests/pipeline/dedup/test_exact_deduplication.py
+++ b/tests/pipeline/dedup/test_exact_deduplication.py
@@ -79,6 +79,45 @@ class UrlDedup(unittest.TestCase):
         self.assertEqual(len(docs), 3)
         self.assertEqual({int(doc.id) for doc in docs}, set(expected_ids))
 
+    def test_url_deduplication_with_zero_priority(self):
+        docs = [
+            Document(text="", metadata={"url": "https://example.com", "priority": 0}, id="0"),
+            Document(text="", metadata={"url": "https://example.com", "priority": 1}, id="1"),
+            Document(text="", metadata={"url": "https://other.com", "priority": 0}, id="2"),
+            Document(text="", metadata={"url": "https://other.com", "priority": 0}, id="3"),
+        ]
+        config = ExactDedupConfig(
+            content_getter=lambda doc: doc.metadata.get("url", ""),
+            document_priority=lambda doc: doc.metadata["priority"],
+        )
+
+        signature_creation = ExactDedupSignature(output_folder=self.tmp_dir + "/sigs", config=config)
+        find_duplicates = ExactFindDedups(
+            data_folder=self.tmp_dir + "/sigs",
+            output_folder=self.tmp_dir + "/dups",
+            config=config,
+        )
+        dedup_filter = ExactDedupFilter(data_folder=self.tmp_dir + "/dups", config=config)
+
+        signature_creation(data=docs)
+        find_duplicates()
+        deduped_docs = list(dedup_filter(data=copy.deepcopy(docs)))
+
+        self.assertEqual([doc.id for doc in deduped_docs], ["1", "2"])
+
+    def test_url_deduplication_rejects_out_of_range_priority(self):
+        config = ExactDedupConfig(
+            content_getter=lambda doc: doc.metadata.get("url", ""),
+            document_priority=lambda doc: doc.metadata["priority"],
+        )
+        signature_creation = ExactDedupSignature(output_folder=self.tmp_dir + "/sigs", config=config)
+
+        for priority in (-1, 65536):
+            with self.subTest(priority=priority):
+                doc = Document(text="", metadata={"url": "https://example.com", "priority": priority}, id="0")
+                with self.assertRaisesRegex(ValueError, "priority must be between 0 and 65535"):
+                    signature_creation(data=[doc])
+
     def test_url_deduplication_with_priority_lowest_id(self):
         config = ExactDedupConfig(
             content_getter=lambda doc: doc.metadata.get("url", ""), document_priority=lambda x: 5 - int(x.id) + 1


### PR DESCRIPTION
## Summary

- Allow exact-dedup document priorities in the range `[0, 65535]`.
- Replace unsigned negation with `priority_max - priority` so that zero remains lower priority than positive values.
- Raise `ValueError` for out-of-range priorities and add regression coverage for zero priorities, ties, and invalid boundaries.

## Motivation

`document_priority` can legitimately return zero. For example, the URL deduplication example uses `len(doc.text) // 4`, which returns zero for documents shorter than four characters.

The current assertion rejects these documents. Simply removing it would also be incorrect because negating an unsigned zero leaves it at zero, causing it to sort before positive priorities.

Fixes #337

## Testing

- `python -m pytest -q tests/pipeline/dedup`
  - `23 passed, 3 skipped, 2 subtests passed`
- `make quality`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which duplicate is kept when sorting signatures by priority. Incorrect inversion would keep the wrong documents.
> 
> **Overview**
> Exact dedup now accepts `document_priority` in `[0, 65535]` instead of rejecting 0.
> 
> Signature sorting no longer negates the unsigned `priority` field (which left 0 unchanged and ranked it above positive values). It inverts with `priority_max - priority` so higher values still sort first. Out-of-range priorities raise `ValueError`.
> 
> Tests cover zero vs positive priority, ties at 0, and bounds `-1` / `65536`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2873228be82f35adc9e8db2a6ddbf0bdcb8ca187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->